### PR TITLE
feat: added validations

### DIFF
--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.json
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.json
@@ -45,7 +45,8 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Is Direct Message"
+   "label": "Is Direct Message",
+   "set_only_once": 1
   },
   {
    "default": "0",
@@ -53,7 +54,8 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Is Self Message"
+   "label": "Is Self Message",
+   "set_only_once": 1
   },
   {
    "fieldname": "channel_description",
@@ -92,7 +94,7 @@
    "link_fieldname": "channel_id"
   }
  ],
- "modified": "2023-09-01 13:59:34.177727",
+ "modified": "2023-09-01 14:12:58.169255",
  "modified_by": "Administrator",
  "module": "Raven Channel Management",
  "name": "Raven Channel",

--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.json
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.json
@@ -22,6 +22,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Type",
    "options": "Private\nPublic\nOpen",
    "reqd": 1
@@ -34,6 +35,7 @@
    "in_preview": 1,
    "in_standard_filter": 1,
    "label": "Channel Name",
+   "read_only_depends_on": "eval: doc.is_direct_message || doc.is_self_message",
    "reqd": 1,
    "unique": 1
   },
@@ -41,12 +43,16 @@
    "default": "0",
    "fieldname": "is_direct_message",
    "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Is Direct Message"
   },
   {
    "default": "0",
    "fieldname": "is_self_message",
    "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Is Self Message"
   },
   {
@@ -70,12 +76,23 @@
    "default": "0",
    "fieldname": "is_archived",
    "fieldtype": "Check",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Is Archived"
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2023-06-15 13:08:28.717219",
+ "links": [
+  {
+   "link_doctype": "Raven Channel Member",
+   "link_fieldname": "channel_id"
+  },
+  {
+   "link_doctype": "Raven Message",
+   "link_fieldname": "channel_id"
+  }
+ ],
+ "modified": "2023-09-01 13:59:34.177727",
  "modified_by": "Administrator",
  "module": "Raven Channel Management",
  "name": "Raven Channel",


### PR DESCRIPTION
The API cannot be removed since the Raven Channel doctype does not store user IDs. I have added documentation and additional checks so that users cannot change the name of the channel