### PR TITLE
feat: added indexing on creation for raven messages

### DIFF
--- a/raven/patches.txt
+++ b/raven/patches.txt
@@ -2,3 +2,4 @@
 
 [post_model_sync]
 raven.patches.v1_2.create_raven_users
+raven.patches.v1_3.create_raven_message_indexes #23

--- a/raven/patches/v1_3/create_raven_message_indexes.py
+++ b/raven/patches/v1_3/create_raven_message_indexes.py
@@ -1,0 +1,4 @@
+from raven.raven_messaging.doctype.raven_message.raven_message import on_doctype_update
+def execute():
+    # Indexing all Raven Messages
+    on_doctype_update()

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -91,6 +91,13 @@ class RavenMessage(Document):
         if frappe.db.get_value('Raven Channel', self.channel_id, 'type') != 'Private' or frappe.db.exists("Raven Channel Member", {"channel_id": self.channel_id, "user_id": frappe.session.user}):
             track_visit(self.channel_id)
 
+def on_doctype_update():
+    '''
+    Add indexes to Raven Message table
+    '''
+    # Index the selector (channel or message type) first for faster queries (less rows to sort in the next step)
+    frappe.db.add_index("Raven Message", ["channel_id", "creation"])
+    frappe.db.add_index("Raven Message", ["message_type", "creation"])
 
 def track_visit(channel_id, commit=False):
     '''


### PR DESCRIPTION
Added two multi-column indexes on "Raven Message"

1. Channel ID and Creation (used to fetch messages in channels)
2. Message type and creation (used during search)

This is in addition to the single column index already applied on Channel ID.

Raven Message Reaction already has an index on Message ID.