### PR TITLE
fix: permissions error for LDAP login

### DIFF
--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -86,7 +86,7 @@ def add_user_to_raven(doc,method):
 				if not doc.full_name:
 					raven_user.full_name = doc.first_name
 				raven_user.enabled = 0
-				raven_user.save()
+				raven_user.save(ignore_permissions=True)
 		else:
 			# Raven user does not exist. Check if the user is a system user.
 			if doc.user_type == "System User":
@@ -111,4 +111,4 @@ def add_user_to_raven(doc,method):
 							if not doc.full_name:
 								raven_user.full_name = doc.first_name
 							raven_user.enabled = 1
-							raven_user.insert()
+							raven_user.insert(ignore_permissions=True)

--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -80,7 +80,7 @@ def add_user_to_raven(doc,method):
 				if not doc.full_name:
 					raven_user.full_name = doc.first_name
 				raven_user.enabled = 1
-				raven_user.save()
+				raven_user.save(ignore_permissions=True)
 			else:
 				raven_user = frappe.get_doc("Raven User", {"user": doc.name})
 				if not doc.full_name:
@@ -102,7 +102,7 @@ def add_user_to_raven(doc,method):
 						if not doc.full_name:
 							raven_user.full_name = doc.first_name
 						raven_user.enabled = 1
-						raven_user.insert()
+						raven_user.insert(ignore_permissions=True)
 					else:
 						if "Raven User" in [d.role for d in doc.get("roles")]:
 							# Create a Raven User record for the user.


### PR DESCRIPTION
Currently with an LDAP login the frappe User stays Guest until DESK is loaded. Guest however does not have permission to create Raven User so an Error is given (and login is not possible)


![Schermafbeelding 2024-01-08 083119-1](https://github.com/The-Commit-Company/Raven/assets/48353029/fe2f8b57-0521-4adc-a1a9-099016c44428)
