### PR TITLE
fix: emoji picker search text not visible in dark mode [#614]

### DIFF
--- a/raven-app/src/components/common/EmojiPicker/EmojiPicker.tsx
+++ b/raven-app/src/components/common/EmojiPicker/EmojiPicker.tsx
@@ -1,13 +1,14 @@
 import { createElement, useEffect, useRef } from "react"
 import 'emoji-picker-element'
 import './emojiPicker.styles.css'
+import { useTheme } from "@/ThemeProvider"
 
 const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
 
     const ref = useRef<any>(null)
+    const { appearance } = useTheme()
 
     useEffect(() => {
-
         const handler = (event: any) => {
             onSelect(event.detail.unicode)
         }
@@ -15,7 +16,7 @@ const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
         ref.current.skinToneEmoji = '👍'
 
         const style = document.createElement('style');
-        style.textContent = `.picker { border-radius: var(--radius-4); box-shadow: var(--shadow-6); }`
+        style.textContent = `.picker { border-radius: var(--radius-4); box-shadow: var(--shadow-6); } input.search{ color: ${appearance === 'light' ? '#020617' : '#f1f5f9' } }`
         ref.current.shadowRoot.appendChild(style);
 
         return () => {


### PR DESCRIPTION
Solution:

Toggle color change depending on the theme. Issue existed because By default, emoji-picker-element will automatically switch to dark mode based on prefers-color-scheme. Used colors from Tailwind's documentation. Can change if required.
Check Working images - 

Dark Mode - 
<img width="1433" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/59260326/89e75b5a-eefa-4bba-8263-2d3ffe721ee6">

Light Mode -
<img width="1433" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/59260326/0f9d5402-433a-42ee-9923-2e48068fffa6">
