### PR TITLE
fix: do not show archived channels in Desk interface

### DIFF
--- a/mobile/src/utils/channel/ChannelListProvider.tsx
+++ b/mobile/src/utils/channel/ChannelListProvider.tsx
@@ -71,7 +71,9 @@ const useFetchChannelList = (): ChannelListContextType => {
             position: 'bottom',
         });
     };
-    const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", undefined, isLoggedIn ? undefined : null, {
+    const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", {
+        hide_archived: false
+    }, isLoggedIn ? undefined : null, {
         revalidateOnFocus: false,
         revalidateIfStale: false,
         onError: (error) => {

--- a/raven-app/src/utils/channel/ChannelListProvider.tsx
+++ b/raven-app/src/utils/channel/ChannelListProvider.tsx
@@ -58,7 +58,9 @@ export const ChannelListProvider = ({ children }: PropsWithChildren) => {
 export const useFetchChannelList = (): ChannelListContextType => {
 
     const { toast } = useToast()
-    const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", undefined, undefined, {
+    const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", {
+        hide_archived: false
+    }, undefined, {
         revalidateOnFocus: false,
         revalidateIfStale: false,
         onError: (error) => {

--- a/raven/api/raven_channel.py
+++ b/raven/api/raven_channel.py
@@ -7,7 +7,7 @@ channel_member = frappe.qb.DocType("Raven Channel Member")
 
 
 @frappe.whitelist()
-def get_all_channels(hide_archived=False):
+def get_all_channels(hide_archived=True):
     '''
         Fetches all channels where current user is a member - both channels and DMs
         To be used on the web app. 


### PR DESCRIPTION
I think we should not fetch archived channels regardless. For now, by default, the API does not fetch archived channels.