### PR TITLE
fix: set min-height and width for avatar in desk interface

### DIFF
--- a/raven/public/scss/avatar.scss
+++ b/raven/public/scss/avatar.scss
@@ -1,6 +1,8 @@
 .raven-avatar {
     width: 1.8rem;
     height: 1.8rem;
+    min-width: 1.8rem;
+    min-height: 1.8rem;
     display: block;
     border-radius: 0.5rem;
 


### PR DESCRIPTION
<img width="423" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/9bda169c-b607-4388-84f2-623dec3b6c8a">
