### PR TITLE
feat: Allow login via username

### DIFF
--- a/raven-app/src/pages/auth/Login.tsx
+++ b/raven-app/src/pages/auth/Login.tsx
@@ -47,25 +47,22 @@ export const Component = () => {
                             {error && <ErrorCallout>
                                 {error.message}
                             </ErrorCallout>}
-                            {/* <ErrorBanner error={error} /> */}
-
+                           
                             <form onSubmit={handleSubmit(onSubmit)}>
                                 <Flex direction='column' gap='6'>
                                     <Flex direction='column' gap='4'>
 
                                         <Flex direction='column' gap='2'>
-                                            <Label htmlFor='email' isRequired>Email address</Label>
+                                            <Label htmlFor='email' isRequired>Email / Username</Label>
                                             <TextField.Root>
                                                 <TextField.Input {...register("email",
                                                     {
-                                                        // validate: (email) => isEmailValid(email) || "Please enter a valid email address.",
-                                                        required: "Email is required."
+                                                        required: "Email or Username is required."
                                                     })}
                                                     name="email"
                                                     type="text"
-                                                    // autoComplete="email"
                                                     required
-                                                    placeholder="e.g. example@gmail.com"
+                                                    placeholder="jane@example.com"
                                                     tabIndex={0} />
                                             </TextField.Root>
                                             {errors?.email && <ErrorText>{errors?.email?.message}</ErrorText>}

--- a/raven-app/src/pages/auth/Login.tsx
+++ b/raven-app/src/pages/auth/Login.tsx
@@ -2,14 +2,13 @@ import { useState, useContext } from "react";
 import { useForm } from "react-hook-form";
 import { BiShow, BiHide } from "react-icons/bi";
 import { Link } from "react-router-dom";
-import { ErrorBanner } from "../../components/layout/AlertBanner";
 import { UserContext } from "../../utils/auth/UserProvider";
-import { isEmailValid } from "../../utils/validations";
 import { FullPageLoader } from "../../components/layout/Loaders";
 import { Box, Button, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
 import { FrappeError } from "frappe-react-sdk";
 import { Loader } from "@/components/common/Loader";
 import { ErrorText, Label } from "@/components/common/Form";
+import { ErrorCallout } from "@/components/layout/AlertBanner/ErrorBanner";
 
 type Inputs = {
     email: string;
@@ -45,7 +44,10 @@ export const Component = () => {
                                 </Flex>
                             </Link>
 
-                            <ErrorBanner error={error} />
+                            {error && <ErrorCallout>
+                                {error.message}
+                            </ErrorCallout>}
+                            {/* <ErrorBanner error={error} /> */}
 
                             <form onSubmit={handleSubmit(onSubmit)}>
                                 <Flex direction='column' gap='6'>
@@ -56,12 +58,12 @@ export const Component = () => {
                                             <TextField.Root>
                                                 <TextField.Input {...register("email",
                                                     {
-                                                        validate: (email) => isEmailValid(email) || "Please enter a valid email address.",
+                                                        // validate: (email) => isEmailValid(email) || "Please enter a valid email address.",
                                                         required: "Email is required."
                                                     })}
                                                     name="email"
-                                                    type="email"
-                                                    autoComplete="email"
+                                                    type="text"
+                                                    // autoComplete="email"
                                                     required
                                                     placeholder="e.g. example@gmail.com"
                                                     tabIndex={0} />

--- a/raven-app/src/utils/auth/UserProvider.tsx
+++ b/raven-app/src/utils/auth/UserProvider.tsx
@@ -39,7 +39,10 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     }
 
     const handleLogin = async (username: string, password: string) => {
-        return login(username, password)
+        return login({
+            username,
+            password
+        })
             .then(() => {
                 //Reload the page so that the boot info is fetched again
                 const URL = import.meta.env.VITE_BASE_NAME ? `/${import.meta.env.VITE_BASE_NAME}` : ``


### PR DESCRIPTION
Fix:
If allow_login_using_user_name is set in System Settings for user, then we can use username while logging in.

Changes Made:
1) Removed email validation
2) Replaced ErrorBanner with ErrorCallout to show error message properly
3) Fixed arguments in login call inside UserProvider's handleLogin