### PR TITLE
fix: API path for creating a DM channel via search

### DIFF
--- a/mobile/src/components/features/channels/channel-members/AddChannelMembers.tsx
+++ b/mobile/src/components/features/channels/channel-members/AddChannelMembers.tsx
@@ -62,7 +62,7 @@ export const AddChannelMembers = ({ presentingElement, isOpen, onDismiss, channe
     const [searchText, setSearchText] = useState('')
 
     const filteredUsers = useMemo(() => {
-        return users.users.filter(member => {
+        return users.enabledUsers.filter(member => {
             return member.name.toLowerCase().includes(searchText.toLowerCase())
         })
     }, [users, searchText])

--- a/mobile/src/components/features/chat-input/Tiptap.tsx
+++ b/mobile/src/components/features/chat-input/Tiptap.tsx
@@ -60,7 +60,7 @@ const ChannelMention = Mention.extend({
     })
 export const Tiptap = ({ onMessageSend, messageSending, defaultText = '' }: TiptapEditorProps) => {
 
-    const { users } = useContext(UserListContext)
+    const { enabledUsers } = useContext(UserListContext)
 
     const { channels } = useContext(ChannelListContext) as ChannelListContextType
 
@@ -114,7 +114,7 @@ export const Tiptap = ({ onMessageSend, messageSending, defaultText = '' }: Tipt
             },
             suggestion: {
                 items: (query) => {
-                    return users.filter((user) => user.full_name.toLowerCase().startsWith(query.query.toLowerCase()))
+                    return enabledUsers.filter((user) => user.full_name.toLowerCase().startsWith(query.query.toLowerCase()))
                         .slice(0, 10);
                 },
                 // char: '@',

--- a/mobile/src/hooks/useGetUserRecords.ts
+++ b/mobile/src/hooks/useGetUserRecords.ts
@@ -13,6 +13,7 @@ export const useGetUserRecords = () => {
                 full_name: user.full_name,
                 user_image: user.user_image ?? '',
                 first_name: user.first_name,
+                enabled: user.enabled
             }
         })
         return usersMap

--- a/mobile/src/types/Raven/RavenSettings.ts
+++ b/mobile/src/types/Raven/RavenSettings.ts
@@ -12,4 +12,6 @@ export interface RavenSettings{
 	idx?: number
 	/**	Automatically add system users to Raven : Check	*/
 	auto_add_system_users?: 0 | 1
+	/**	Show Raven on Desk : Check	*/
+	show_raven_on_desk?: 0 | 1
 }

--- a/mobile/src/types/Raven/RavenUser.ts
+++ b/mobile/src/types/Raven/RavenUser.ts
@@ -1,5 +1,5 @@
 
-export interface RavenUser{
+export interface RavenUser {
 	creation: string
 	name: string
 	modified: string
@@ -17,5 +17,6 @@ export interface RavenUser{
 	/**	First Name : Data	*/
 	first_name?: string
 	/**	User Image : Attach Image	*/
-	user_image?: string
+	user_image?: string,
+	enabled: 0 | 1
 }

--- a/mobile/src/types/RavenMessaging/RavenMessage.ts
+++ b/mobile/src/types/RavenMessaging/RavenMessage.ts
@@ -1,5 +1,5 @@
 
-export interface RavenMessage{
+export interface RavenMessage {
 	creation: string
 	name: string
 	modified: string
@@ -16,8 +16,18 @@ export interface RavenMessage{
 	text?: string
 	/**	JSON : JSON	*/
 	json?: any
+	/**	Message Reactions : JSON	*/
+	message_reactions?: any
+	/**	Is Reply : Check	*/
+	is_reply?: 0 | 1
+	/**	Replied Message ID : Link - Raven Message	*/
+	linked_message?: string
+	/**	Replied Message Details : JSON	*/
+	replied_message_details?: any
 	/**	Message Type : Select	*/
 	message_type?: "Text" | "Image" | "File"
+	/**	Content : Long Text	*/
+	content?: string
 	/**	File : Attach	*/
 	file?: string
 	/**	Image Width : Data	*/
@@ -30,16 +40,10 @@ export interface RavenMessage{
 	thumbnail_width?: string
 	/**	Thumbnail Height : Data	*/
 	thumbnail_height?: string
-	/**	Message Reactions : JSON	*/
-	message_reactions?: any
-	/**	Is Reply : Check	*/
-	is_reply?: 0 | 1
-	/**	Linked Message : Link - Raven Message	*/
-	linked_message?: string
 	/**	Link Doctype : Link - DocType	*/
 	link_doctype?: string
 	/**	Link Document : Dynamic Link	*/
 	link_document?: string
-	/**	Content : Long Text	*/
-	content?: string
+	/**	Is Edited : Check	*/
+	is_edited?: 0 | 1
 }

--- a/mobile/src/utils/users/UserListProvider.tsx
+++ b/mobile/src/utils/users/UserListProvider.tsx
@@ -1,17 +1,18 @@
 import { FrappeError, useFrappeDocTypeEventListener, useFrappeGetCall } from "frappe-react-sdk";
-import { PropsWithChildren, createContext, useContext } from "react";
-import { User } from "../../../../types/Core/User";
+import { PropsWithChildren, createContext, useContext, useMemo } from "react";
 import { UserContext } from "../auth/UserProvider";
 import { ErrorBanner } from "@/components/layout";
 import { IonButton, IonButtons, IonContent, IonFooter, IonHeader, IonPage, IonTitle, IonToolbar } from "@ionic/react";
 import { FullPageLoader } from "@/components/layout/loaders";
+import { RavenUser } from "@/types/Raven/RavenUser";
 
 
-export const UserListContext = createContext<{ users: UserFields[] }>({
-    users: []
+export const UserListContext = createContext<{ users: UserFields[], enabledUsers: UserFields[] }>({
+    users: [],
+    enabledUsers: []
 })
 
-export type UserFields = Pick<User, 'name' | 'full_name' | 'user_image' | 'first_name'>
+export type UserFields = Pick<RavenUser, 'name' | 'full_name' | 'user_image' | 'first_name' | 'enabled'>
 
 /** Hook to fetch a list of users */
 export const useUserList = () => {
@@ -22,13 +23,20 @@ export const useUserList = () => {
 export const UserListProvider = ({ children }: PropsWithChildren) => {
 
     const { isLoggedIn } = useContext(UserContext)
-    const { data, error: usersError, isLoading, mutate } = useFrappeGetCall<{ message: UserFields[] }>('raven.api.raven_users.get_list', undefined, isLoggedIn ? undefined : null, {
+    const { data, error: usersError, isLoading, mutate } = useFrappeGetCall<{ message: UserFields[] }>('raven.api.raven_users.get_list', undefined, isLoggedIn ? 'raven.api.raven_users.get_list' : null, {
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
         errorRetryCount: 10
     })
 
     useFrappeDocTypeEventListener('User', () => mutate())
+
+    const { users, enabledUsers } = useMemo(() => {
+        return {
+            users: data?.message ?? [],
+            enabledUsers: data?.message?.filter(user => user.enabled === 1) ?? []
+        }
+    }, [data])
 
     if (isLoading) {
         return <FullPageLoader />
@@ -37,7 +45,7 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
         return <ErrorPage error={usersError} mutate={mutate} />
     }
 
-    return <UserListContext.Provider value={{ users: data?.message ?? [] }}>
+    return <UserListContext.Provider value={{ users, enabledUsers }}>
         {children}
     </UserListContext.Provider>
 

--- a/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -73,7 +73,7 @@ export const ChannelMention = Mention.extend({
     })
 const Tiptap = ({ slotBefore, fileProps, onMessageSend, clearReplyMessage, placeholder = 'Type a message...', messageSending, sessionStorageKey = 'tiptap-editor', disableSessionStorage = false, defaultText = '' }: TiptapEditorProps) => {
 
-    const { users } = useContext(UserListContext)
+    const { enabledUsers } = useContext(UserListContext)
 
     const { channels } = useContext(ChannelListContext) as ChannelListContextType
 
@@ -264,7 +264,7 @@ const Tiptap = ({ slotBefore, fileProps, onMessageSend, clearReplyMessage, place
             },
             suggestion: {
                 items: (query) => {
-                    return users.filter((user) => user.full_name.toLowerCase().startsWith(query.query.toLowerCase()))
+                    return enabledUsers.filter((user) => user.full_name.toLowerCase().startsWith(query.query.toLowerCase()))
                         .slice(0, 10);
                 },
                 // char: '@',

--- a/raven-app/src/components/feature/command-palette/CommandPalette.tsx
+++ b/raven-app/src/components/feature/command-palette/CommandPalette.tsx
@@ -38,7 +38,7 @@ export const CommandPalette = ({ isOpen, onClose }: CommandPaletteProps) => {
     const debouncedText = useDebounce(inputValue, 200)
     const { currentUser } = useContext(UserContext)
     const activeUsers = useContext(ActiveUsersContext)
-    const { call, reset } = useFrappePostCall<{ message: string }>("raven.raven_channel_management.doctype.raven_channel.raven_channel.create_direct_message_channel")
+    const { call, reset } = useFrappePostCall<{ message: string }>("raven.api.raven_channel.create_direct_message_channel")
     let navigate = useNavigate()
 
     const gotoDMChannel = async (user: string) => {

--- a/raven-app/src/components/feature/raven-users/AddRavenUsersContent.tsx
+++ b/raven-app/src/components/feature/raven-users/AddRavenUsersContent.tsx
@@ -42,7 +42,7 @@ const AddRavenUsersContent = ({ onClose }: { onClose: VoidFunction }) => {
     })
 
     const users = useContext(UserListContext)
-    const ravenUsersArray = users.users.map(user => user.name)
+    const ravenUsersArray = users.enabledUsers.map(user => user.name)
 
     const [selected, setSelected] = useState<string[]>([])
     const { loading, call, error: postError } = useFrappePostCall('raven.api.raven_users.add_users_to_raven')

--- a/raven-app/src/components/feature/select-member/AddMembersDropdown.tsx
+++ b/raven-app/src/components/feature/select-member/AddMembersDropdown.tsx
@@ -21,7 +21,7 @@ const AddMembersDropdown = ({ channelMembers, label = 'Select users', selectedUs
     const users = useContext(UserListContext)
 
     //Options for dropdown
-    const nonChannelMembers = users.users?.filter((m: UserFields) => !channelMembers?.[m.name]) ?? []
+    const nonChannelMembers = users.enabledUsers?.filter((m: UserFields) => !channelMembers?.[m.name]) ?? []
 
     /** Function to filter users */
     function getFilteredUsers(selectedUsers: UserFields[], inputValue: string) {
@@ -170,7 +170,7 @@ const AddMembersDropdown = ({ channelMembers, label = 'Select users', selectedUs
                     </TextField.Root>
                 </div >
                 <ul
-                    className={`absolute w-inherit bg-background rounded-b-md mt-1 shadow-md max-h-36 overflow-scroll p-0 z-50 ${!(isOpen && items.length) && 'hidden'
+                    className={`absolute w-96 bg-background rounded-b-md mt-1 shadow-md max-h-96 overflow-scroll p-0 z-50 ${!(isOpen && items.length) && 'hidden'
                         }`}
                     {...getMenuProps()}
                 >

--- a/raven-app/src/hooks/useGetUserRecords.ts
+++ b/raven-app/src/hooks/useGetUserRecords.ts
@@ -13,6 +13,7 @@ export const useGetUserRecords = () => {
                 full_name: user.full_name,
                 user_image: user.user_image ?? '',
                 first_name: user.first_name,
+                enabled: user.enabled
             }
         })
         return usersMap

--- a/raven-app/src/pages/AddRavenUsersPage.tsx
+++ b/raven-app/src/pages/AddRavenUsersPage.tsx
@@ -21,7 +21,7 @@ import { Loader } from '@/components/common/Loader'
 const AddRavenUsersPage = () => {
 
     const canAddRavenUsers = isSystemManager()
-    console.log('canAddRavenUsers', canAddRavenUsers)
+
     return (
         <Container>
             <Flex align='center' justify='center' className='h-screen'>

--- a/raven-app/src/types/Raven/RavenSettings.ts
+++ b/raven-app/src/types/Raven/RavenSettings.ts
@@ -12,4 +12,6 @@ export interface RavenSettings{
 	idx?: number
 	/**	Automatically add system users to Raven : Check	*/
 	auto_add_system_users?: 0 | 1
+	/**	Show Raven on Desk : Check	*/
+	show_raven_on_desk?: 0 | 1
 }

--- a/raven-app/src/types/Raven/RavenUser.ts
+++ b/raven-app/src/types/Raven/RavenUser.ts
@@ -1,5 +1,5 @@
 
-export interface RavenUser{
+export interface RavenUser {
 	creation: string
 	name: string
 	modified: string
@@ -17,5 +17,6 @@ export interface RavenUser{
 	/**	First Name : Data	*/
 	first_name?: string
 	/**	User Image : Attach Image	*/
-	user_image?: string
+	user_image?: string,
+	enabled: 0 | 1
 }

--- a/raven-app/src/types/RavenMessaging/RavenMessage.ts
+++ b/raven-app/src/types/RavenMessaging/RavenMessage.ts
@@ -1,5 +1,5 @@
 
-export interface RavenMessage{
+export interface RavenMessage {
 	creation: string
 	name: string
 	modified: string
@@ -16,8 +16,18 @@ export interface RavenMessage{
 	text?: string
 	/**	JSON : JSON	*/
 	json?: any
+	/**	Message Reactions : JSON	*/
+	message_reactions?: any
+	/**	Is Reply : Check	*/
+	is_reply?: 0 | 1
+	/**	Replied Message ID : Link - Raven Message	*/
+	linked_message?: string
+	/**	Replied Message Details : JSON	*/
+	replied_message_details?: any
 	/**	Message Type : Select	*/
 	message_type?: "Text" | "Image" | "File"
+	/**	Content : Long Text	*/
+	content?: string
 	/**	File : Attach	*/
 	file?: string
 	/**	Image Width : Data	*/
@@ -30,16 +40,10 @@ export interface RavenMessage{
 	thumbnail_width?: string
 	/**	Thumbnail Height : Data	*/
 	thumbnail_height?: string
-	/**	Message Reactions : JSON	*/
-	message_reactions?: any
-	/**	Is Reply : Check	*/
-	is_reply?: 0 | 1
-	/**	Linked Message : Link - Raven Message	*/
-	linked_message?: string
 	/**	Link Doctype : Link - DocType	*/
 	link_doctype?: string
 	/**	Link Document : Dynamic Link	*/
 	link_document?: string
-	/**	Content : Long Text	*/
-	content?: string
+	/**	Is Edited : Check	*/
+	is_edited?: 0 | 1
 }

--- a/raven-app/src/utils/channel/ChannelListProvider.tsx
+++ b/raven-app/src/utils/channel/ChannelListProvider.tsx
@@ -60,7 +60,7 @@ export const useFetchChannelList = (): ChannelListContextType => {
     const { toast } = useToast()
     const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", {
         hide_archived: false
-    }, undefined, {
+    }, `channel_list`, {
         revalidateOnFocus: false,
         revalidateIfStale: false,
         onError: (error) => {

--- a/raven-app/src/utils/users/UserListProvider.tsx
+++ b/raven-app/src/utils/users/UserListProvider.tsx
@@ -1,16 +1,17 @@
 import { useFrappeDocTypeEventListener, useFrappeGetCall, useSWRConfig } from "frappe-react-sdk";
-import { PropsWithChildren, createContext } from "react";
-import { User } from "../../../../types/Core/User";
+import { PropsWithChildren, createContext, useMemo } from "react";
 import { ErrorBanner } from "@/components/layout/AlertBanner";
 import { FullPageLoader } from "@/components/layout/Loaders";
 import { Box, Flex, Link } from "@radix-ui/themes";
+import { RavenUser } from "@/types/Raven/RavenUser";
 
 
-export const UserListContext = createContext<{ users: UserFields[] }>({
-    users: []
+export const UserListContext = createContext<{ users: UserFields[], enabledUsers: UserFields[] }>({
+    users: [],
+    enabledUsers: []
 })
 
-export type UserFields = Pick<User, 'name' | 'full_name' | 'user_image' | 'first_name'>
+export type UserFields = Pick<RavenUser, 'name' | 'full_name' | 'user_image' | 'first_name' | 'enabled'>
 
 export const UserListProvider = ({ children }: PropsWithChildren) => {
 
@@ -28,6 +29,13 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
         globalMutate(`channel_list`)
     })
 
+    const { users, enabledUsers } = useMemo(() => {
+        return {
+            users: data?.message ?? [],
+            enabledUsers: data?.message?.filter(user => user.enabled === 1) ?? []
+        }
+    }, [data])
+
     if (isLoading) {
         return <FullPageLoader />
     }
@@ -41,7 +49,7 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
         </Flex>
     }
 
-    return <UserListContext.Provider value={{ users: data?.message ?? [] }}>
+    return <UserListContext.Provider value={{ users, enabledUsers }}>
         {children}
     </UserListContext.Provider>
 }

--- a/raven-app/src/utils/users/UserListProvider.tsx
+++ b/raven-app/src/utils/users/UserListProvider.tsx
@@ -1,4 +1,4 @@
-import { useFrappeDocTypeEventListener, useFrappeGetCall } from "frappe-react-sdk";
+import { useFrappeDocTypeEventListener, useFrappeGetCall, useSWRConfig } from "frappe-react-sdk";
 import { PropsWithChildren, createContext } from "react";
 import { User } from "../../../../types/Core/User";
 import { ErrorBanner } from "@/components/layout/AlertBanner";
@@ -15,12 +15,18 @@ export type UserFields = Pick<User, 'name' | 'full_name' | 'user_image' | 'first
 export const UserListProvider = ({ children }: PropsWithChildren) => {
 
 
+    const { mutate: globalMutate } = useSWRConfig()
     const { data, error: usersError, mutate, isLoading } = useFrappeGetCall<{ message: UserFields[] }>('raven.api.raven_users.get_list', undefined, 'raven.api.raven_users.get_list', {
         revalidateOnFocus: false,
         revalidateOnReconnect: false,
     })
 
-    useFrappeDocTypeEventListener('User', () => mutate())
+    useFrappeDocTypeEventListener('Raven User', () => {
+        mutate()
+
+        // Mutate the channel list as well
+        globalMutate(`channel_list`)
+    })
 
     if (isLoading) {
         return <FullPageLoader />

--- a/raven/api/raven_channel.py
+++ b/raven/api/raven_channel.py
@@ -97,10 +97,11 @@ def get_extra_users(dm_channels):
                       for dm_channel in dm_channels]
     existing_users.append('Administrator')
     existing_users.append('Guest')
-    return frappe.db.get_list('User', filters=[
+
+    # Skip permissions since we are only fetching user_id, full_name, and user_image and have applied filters
+    return frappe.db.get_all('User', filters=[
         ['name', 'not in', existing_users],
         ['enabled', '=', 1],
-        ['user_type', '=', 'System User'],
         ["Has Role", "role", "=", 'Raven User']], fields=['name', 'full_name', 'user_image'])
 
 

--- a/raven/api/raven_users.py
+++ b/raven/api/raven_users.py
@@ -16,8 +16,10 @@ def get_list():
     if not frappe.db.exists("Raven User", { "user": frappe.session.user }):
         frappe.throw(_("You do not have a <b>Raven User</b> profile. Please contact your administrator to add your user profile as a <b>Raven User</b>."), title="Insufficient permissions. Please contact your administrator.")
     
-    users = frappe.db.get_all("Raven User", fields=["full_name", "user_image",
+    users = frappe.db.get_all("Raven User", 
+                              fields=["full_name", "user_image",
                                    "name", "first_name"],
+                                   filters=[['enabled', '=', 1]],
                            order_by="full_name")
     return users
 

--- a/raven/api/raven_users.py
+++ b/raven/api/raven_users.py
@@ -29,12 +29,26 @@ def add_users_to_raven(users):
     if isinstance(users, str):
         users = json.loads(users)
     
+    failed_users = []
+    success_users = []
+
     for user in users:
         user_doc = frappe.get_doc("User", user)
-        user_doc.append("roles", {
-            "role": "Raven User"
-        })
-        user_doc.save()
+
+        if user_doc.role_profile_name:
+            failed_users.append(user_doc)
+        
+        elif hasattr(user_doc, 'role_profiles') and len(user_doc.role_profiles) > 0:
+            failed_users.append(user_doc)
+        else:
+            user_doc.append("roles", {
+                "role": "Raven User"
+            })
+            user_doc.save()
+            success_users.append(user_doc)
     
-    return "success"
+    return {
+        "success_users": success_users,
+        "failed_users": failed_users
+    }
             

--- a/raven/api/raven_users.py
+++ b/raven/api/raven_users.py
@@ -18,8 +18,7 @@ def get_list():
     
     users = frappe.db.get_all("Raven User", 
                               fields=["full_name", "user_image",
-                                   "name", "first_name"],
-                                   filters=[['enabled', '=', 1]],
+                                   "name", "first_name", "enabled"],
                            order_by="full_name")
     return users
 

--- a/raven/raven/doctype/raven_user/raven_user.json
+++ b/raven/raven/doctype/raven_user/raven_user.json
@@ -61,7 +61,7 @@
  ],
  "image_field": "user_image",
  "links": [],
- "modified": "2023-12-08 04:14:02.588812",
+ "modified": "2024-02-23 00:05:54.819092",
  "modified_by": "Administrator",
  "module": "Raven",
  "name": "Raven User",

--- a/raven/raven_messaging/doctype/raven_message/raven_message.json
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.json
@@ -26,7 +26,6 @@
   "thumbnail_height",
   "link_doctype",
   "link_document",
-  "content",
   "is_edited"
  ],
  "fields": [


### PR DESCRIPTION
Also fixed the following:

1. List of Raven Users on the sidebar with which DM is not created was running a `get_list` query. If the user does not have access to the "User" doctype, this would fail. Changed this call to `get_all`. This will be changed later since we only want to query Raven User - but names would not be matching due to #658. 
2. When a Raven User is updated, we now update the User list as well as the channel list
3. User list fetched consists of both enabled and disabled users since there might be older messages for which we need to show names/avatars. But, while mentioning a user or adding them to a channel, we only enabled users. We would later also add a banner on DMs to inform users that a particular DM is disabled.
4. Website users can now be added as Raven Users
5. In Frappe v15, multiple role profiles can be attached to a user. This cannot be fetched via the list API since it's in a child table. Hence, when adding new users to Raven, if some users are not added, we show an error message in the dialog itself.