### PR TITLE
fix: do not escape underscores in url while copying

### DIFF
--- a/mobile/src/components/features/chat-space/MessageActions/CopyAction.tsx
+++ b/mobile/src/components/features/chat-space/MessageActions/CopyAction.tsx
@@ -42,7 +42,7 @@ const CopyActionItem = ({ message, onSuccess }: ActionProps) => {
         turndownService.addRule('links', {
             filter: 'a',
             replacement: function (content, node, options) {
-                return content
+                return node.textContent ?? content
             }
         })
         var markdown = turndownService.turndown(text)

--- a/raven-app/src/components/feature/chat/ChatMessage/MessageActions/useMessageCopy.ts
+++ b/raven-app/src/components/feature/chat/ChatMessage/MessageActions/useMessageCopy.ts
@@ -17,14 +17,15 @@ export const useMessageCopy = (message: Message) => {
             })
 
             // We want the links to not be converted to markdown links
-
+            // Do not escape the "underscores" in the link text
             turndownService.addRule('links', {
                 filter: 'a',
                 replacement: function (content, node, options) {
-                    return content
+                    return node.textContent ?? content
                 }
             })
             var markdown = turndownService.turndown(text)
+
             if (markdown) {
                 navigator.clipboard.writeText(markdown)
                 toast({


### PR DESCRIPTION
Should fix the issue. Tested it with a few URLs. Might not work later when we have the ability to have text content different from links (embedded links)