### PR TITLE
fix: autofocus input-otp when component loads

### DIFF
--- a/mobile/src/components/ui/input-otp.tsx
+++ b/mobile/src/components/ui/input-otp.tsx
@@ -10,6 +10,7 @@ const InputOTP = React.forwardRef<
 >(({ className, containerClassName, ...props }, ref) => (
   <OTPInput
     ref={ref}
+    autoFocus
     containerClassName={cn(
       "flex items-center justify-center gap-2 has-[:disabled]:opacity-50",
       containerClassName


### PR DESCRIPTION
Solution:
- add autofocus prop to OTPInput component. This is done with reference to [Shadcn's doc reference for input-otp](https://github.com/guilhermerodz/input-otp)