### PR TITLE
fix: update unread channel counts when channel list is updated

### DIFF
--- a/mobile/src/utils/channel/ChannelListProvider.tsx
+++ b/mobile/src/utils/channel/ChannelListProvider.tsx
@@ -4,6 +4,7 @@ import { KeyedMutator } from 'swr'
 import { useIonToast } from '@ionic/react'
 import { RavenChannel } from '../../../../types/RavenChannelManagement/RavenChannel'
 import { UserContext } from '../auth/UserProvider'
+import { useSWRConfig } from 'frappe-react-sdk'
 
 export type ExtraUsersData = {
     name: string,
@@ -73,6 +74,8 @@ const useFetchChannelList = (): ChannelListContextType => {
             position: 'bottom',
         });
     };
+
+    const { mutate: globalMutate } = useSWRConfig()
     const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", {
         hide_archived: false
     }, isLoggedIn ? undefined : null, {
@@ -85,6 +88,9 @@ const useFetchChannelList = (): ChannelListContextType => {
 
     useFrappeDocTypeEventListener('Raven Channel', () => {
         mutate()
+
+        // Also update the unread channel count
+        globalMutate('unread_channel_count')
     })
 
     return {

--- a/raven-app/src/utils/channel/ChannelListProvider.tsx
+++ b/raven-app/src/utils/channel/ChannelListProvider.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, createContext } from 'react'
 import { KeyedMutator } from 'swr'
 import { RavenChannel } from '../../../../types/RavenChannelManagement/RavenChannel'
 import { useToast } from '@/hooks/useToast'
+import { useSWRConfig } from 'frappe-react-sdk'
 
 export type ExtraUsersData = {
     name: string,
@@ -60,6 +61,7 @@ export const ChannelListProvider = ({ children }: PropsWithChildren) => {
 export const useFetchChannelList = (): ChannelListContextType => {
 
     const { toast } = useToast()
+    const { mutate: globalMutate } = useSWRConfig()
     const { data, mutate, ...rest } = useFrappeGetCall<{ message: ChannelList }>("raven.api.raven_channel.get_all_channels", {
         hide_archived: false
     }, `channel_list`, {
@@ -75,6 +77,9 @@ export const useFetchChannelList = (): ChannelListContextType => {
 
     useFrappeDocTypeEventListener('Raven Channel', () => {
         mutate()
+
+        // Also update the unread channel count
+        globalMutate('unread_channel_count')
     })
 
     return {


### PR DESCRIPTION
Unread channel count data was not being updated when the channel list was updated. So even though the unread count event was received, it was not updating it since it did not find it in the unread count list.

Fixed now:
https://github.com/The-Commit-Company/Raven/assets/19825455/4800b50f-a605-453d-bad1-37584e306fda

