### PR TITLE
fix: do not show preview links if not available

### DIFF
--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Link.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Link.tsx
@@ -93,22 +93,24 @@ export const LinkPreview = memo(({ isScrolling }: { isScrolling?: boolean }) => 
 
     return <a href={href} target='_blank'>
         <Flex direction='column' gap='2' py='2'>
-            {linkPreview ? linkPreview.site_name ? <Flex gap='4'>
-                <Box className='relative min-w-[18rem] min-h-[9rem] w-72 h-36'>
-                    {/* Absolute positioned skeleton loader */}
-                    <Box className='absolute top-0 z-0 left-0 w-72 h-36' >
-                        <Box className='animate-pulse bg-gray-3 z-0 w-72 h-36 dark:bg-gray-5 rounded-md'>
+            {linkPreview ? linkPreview.site_name && linkPreview.description ? <Flex gap='4'>
+                {(linkPreview.absolute_image || linkPreview.image) &&
+                    <Box className='relative min-w-[18rem] min-h-[9rem] w-72 h-36'>
+                        {/* Absolute positioned skeleton loader */}
+                        <Box className='absolute top-0 z-0 left-0 w-72 h-36' >
+                            <Box className='animate-pulse bg-gray-3 z-0 w-72 h-36 dark:bg-gray-5 rounded-md'>
 
+                            </Box>
                         </Box>
-                    </Box>
-                    {(linkPreview.absolute_image || linkPreview.image) &&
+
                         <img
                             width='100%'
                             className='absolute object-cover min-w-[18rem] min-h-[9rem] w-72 h-36 rounded-md z-50 top-0 left-0'
                             src={linkPreview.absolute_image || linkPreview.image}
                             alt={linkPreview.title} />
-                    }
-                </Box>
+
+                    </Box>
+                }
                 <Flex direction='column' gap='1' py='1' className='w-84'>
                     <Flex gap='1' direction='column'>
                         <Text as='span' weight='bold' size='5' className='cal-sans'>{linkPreview.title}</Text>
@@ -118,29 +120,7 @@ export const LinkPreview = memo(({ isScrolling }: { isScrolling?: boolean }) => 
                 </Flex>
             </Flex> : null :
 
-                <Flex gap='4'>
-                    <Box className='relative min-w-[18rem] min-h-[9rem] w-72 h-36'>
-                        {/* Absolute positioned skeleton loader */}
-                        <Box className='absolute top-0 z-0 left-0 w-72 h-36' >
-                            <Box className='animate-pulse bg-gray-3 z-0 w-72 h-36 dark:bg-gray-5 rounded-md'>
-
-                            </Box>
-                        </Box>
-                    </Box>
-                    <Flex direction='column' gap='1' py='1' className='w-84'>
-                        <Flex gap='1' direction='column'>
-                            <Text as='span' weight='bold' size='5' className='cal-sans'><Skeleton className='w-48 h-6' /></Text>
-                            <Text as='span' color='gray' size='2' weight='medium'><Skeleton className='w-64 h-4' /></Text>
-                        </Flex>
-                        <Text as='p' size='2' className='whitespace-break-spaces line-clamp-2'>{isScrolling ?
-                            <Flex direction='column' gap='1' pt='2'>
-                                <Skeleton className='h-2 w-72' />
-                                <Skeleton className='h-2 w-96' />
-                            </Flex>
-
-                            : href}</Text>
-                    </Flex>
-                </Flex>}
+                null}
         </Flex>
     </a>
 


### PR DESCRIPTION
If no description is found, do not show the link preview. 

If no image is found, do not show skeleton loader.

<img width="937" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/8f0fa254-958c-4397-b27f-d03debe4fc5f">
