### PR TITLE
feat: allow changing of channel types for channel admins

### DIFF
--- a/raven-app/src/components/feature/channel-details/ChannelDetails.tsx
+++ b/raven-app/src/components/feature/channel-details/ChannelDetails.tsx
@@ -55,7 +55,7 @@ export const ChannelDetails = ({ channelData, channelMembers, onClose }: Channel
                     <Flex direction={'column'} gap='1'>
                         <Text weight='medium' size='2'>Created by</Text>
                         <Flex gap='1'>
-                            {channelData?.owner && <Text size='1'>{users[channelData.owner]?.full_name}</Text>}
+                            {channelData?.owner && <Text size='1'>{users[channelData.owner]?.full_name ?? channelData?.owner}</Text>}
                             {channelData.creation && <Text size='1' color='gray' as='span'>on <DateMonthYear date={channelData?.creation} /></Text>}
                         </Flex>
                     </Flex>

--- a/raven-app/src/components/feature/channel-settings/change-channel-type/ChangeChannelTypeButton.tsx
+++ b/raven-app/src/components/feature/channel-settings/change-channel-type/ChangeChannelTypeButton.tsx
@@ -1,14 +1,30 @@
 import { ChannelListItem } from '@/utils/channel/ChannelListProvider'
-import { BiHash, BiLockAlt } from 'react-icons/bi'
+import { BiGlobe, BiHash, BiLockAlt } from 'react-icons/bi'
 import { ChangeChannelTypeModal } from './ChangeChannelTypeModal'
 import { useState } from 'react'
 import { Button, Dialog } from '@radix-ui/themes'
 import { DIALOG_CONTENT_CLASS } from '@/utils/layout/dialog'
+
 interface ChangeChannelTypeButtonProps {
     channelData: ChannelListItem
 }
 
 export const ChangeChannelTypeButton = ({ channelData }: ChangeChannelTypeButtonProps) => {
+    return (
+        <>
+            {channelData.type === 'Public' && <ChangeChannelTypePublicPrivate channelData={channelData} />}
+            {channelData.type === 'Public' && <ChangeChannelTypeOpenPublic channelData={channelData} />}
+
+            {channelData.type === 'Private' && <ChangeChannelTypePublicPrivate channelData={channelData} />}
+            {channelData.type === 'Private' && <ChangeChannelTypeOpenPrivate channelData={channelData} />}
+
+            {channelData.type === 'Open' && <ChangeChannelTypeOpenPublic channelData={channelData} />}
+            {channelData.type === 'Open' && <ChangeChannelTypeOpenPrivate channelData={channelData} />}
+        </>
+    )
+}
+
+const ChangeChannelTypePublicPrivate = ({ channelData }: ChangeChannelTypeButtonProps) => {
 
     const [open, setOpen] = useState(false)
     const onClose = () => {
@@ -25,6 +41,57 @@ export const ChangeChannelTypeButton = ({ channelData }: ChangeChannelTypeButton
             </Dialog.Trigger>
             <Dialog.Content className={DIALOG_CONTENT_CLASS}>
                 <ChangeChannelTypeModal
+                    newChannelType={channelData.type === 'Public' ? 'Private' : 'Public'}
+                    onClose={onClose}
+                    channelData={channelData} />
+            </Dialog.Content>
+        </Dialog.Root>
+    )
+}
+
+const ChangeChannelTypeOpenPublic = ({ channelData }: ChangeChannelTypeButtonProps) => {
+
+    const [open, setOpen] = useState(false)
+    const onClose = () => {
+        setOpen(false)
+    }
+
+    return (
+        <Dialog.Root open={open} onOpenChange={setOpen}>
+            <Dialog.Trigger>
+                <Button color='gray' variant='surface'>
+                    {channelData.type === 'Open' ? <BiHash /> : <BiGlobe />}
+                    Change to a {channelData.type === 'Open' ? 'public' : 'open'} channel
+                </Button>
+            </Dialog.Trigger>
+            <Dialog.Content className={DIALOG_CONTENT_CLASS}>
+                <ChangeChannelTypeModal
+                    newChannelType={channelData.type === 'Open' ? 'Public' : 'Open'}
+                    onClose={onClose}
+                    channelData={channelData} />
+            </Dialog.Content>
+        </Dialog.Root>
+    )
+}
+
+const ChangeChannelTypeOpenPrivate = ({ channelData }: ChangeChannelTypeButtonProps) => {
+
+    const [open, setOpen] = useState(false)
+    const onClose = () => {
+        setOpen(false)
+    }
+
+    return (
+        <Dialog.Root open={open} onOpenChange={setOpen}>
+            <Dialog.Trigger>
+                <Button color='gray' variant='surface'>
+                    {channelData.type === 'Open' ? <BiLockAlt /> : <BiGlobe />}
+                    Change to a {channelData.type === 'Open' ? 'private' : 'open'} channel
+                </Button>
+            </Dialog.Trigger>
+            <Dialog.Content className={DIALOG_CONTENT_CLASS}>
+                <ChangeChannelTypeModal
+                    newChannelType={channelData.type === 'Open' ? 'Private' : 'Open'}
                     onClose={onClose}
                     channelData={channelData} />
             </Dialog.Content>

--- a/raven-app/src/components/feature/channel-settings/change-channel-type/ChangeChannelTypeModal.tsx
+++ b/raven-app/src/components/feature/channel-settings/change-channel-type/ChangeChannelTypeModal.tsx
@@ -1,4 +1,4 @@
-import { useFrappeUpdateDoc } from 'frappe-react-sdk'
+import { useFrappeUpdateDoc, useSWRConfig } from 'frappe-react-sdk'
 import { ErrorBanner } from '../../../layout/AlertBanner'
 import { ChannelListItem } from '@/utils/channel/ChannelListProvider'
 import { Button, Dialog, Flex, Text } from '@radix-ui/themes'
@@ -7,19 +7,21 @@ import { useToast } from '@/hooks/useToast'
 
 interface ChangeChannelTypeModalProps {
     onClose: () => void
-    channelData: ChannelListItem
+    channelData: ChannelListItem,
+    newChannelType: 'Public' | 'Private' | 'Open'
 }
 
-export const ChangeChannelTypeModal = ({ onClose, channelData }: ChangeChannelTypeModalProps) => {
+export const ChangeChannelTypeModal = ({ onClose, channelData, newChannelType }: ChangeChannelTypeModalProps) => {
 
     const { toast } = useToast()
+    const { mutate } = useSWRConfig()
     const { updateDoc, loading: updatingDoc, error } = useFrappeUpdateDoc()
-    const new_channel_type = channelData?.type === 'Public' ? 'Private' : 'Public'
 
-    const changeChannelType = (new_channel_type: 'Public' | 'Private') => {
+    const changeChannelType = (newChannelType: 'Public' | 'Private' | 'Open') => {
         updateDoc("Raven Channel", channelData?.name ?? null, {
-            type: new_channel_type
+            type: newChannelType
         }).then(() => {
+            mutate(`raven.api.chat.get_channel_members:${channelData.name}`)
             toast({
                 title: "Channel type updated",
                 variant: "success",
@@ -31,22 +33,29 @@ export const ChangeChannelTypeModal = ({ onClose, channelData }: ChangeChannelTy
 
     return (
         <>
-            <Dialog.Title>Change to a {new_channel_type.toLocaleLowerCase()} channel?</Dialog.Title>
+            <Dialog.Title>Change to a {newChannelType.toLocaleLowerCase()} channel?</Dialog.Title>
 
             <Flex gap='2' direction='column' width='100%'>
                 <ErrorBanner error={error} />
-                {channelData?.type === 'Private' && <Flex direction='column' gap='4'>
+                {newChannelType === 'Public' && <Flex direction='column' gap='4'>
                     <Text size='2'>Please understand that when you make <strong>{channelData?.channel_name}</strong> a public channel:</Text>
                     <ul className={'list-inside'}>
                         <li><Text size='1'>Anyone from your organisation can join this channel and view its message history.</Text></li>
-                        <li><Text size='1'>If you make this channel private again, it willbe visible to anyone who has joined the channel up until that point.</Text></li>
+                        <li><Text size='1'>If you make this channel private, it will be visible to anyone who has joined the channel up until that point.</Text></li>
                     </ul>
                 </Flex>}
-                {channelData?.type === 'Public' && <Flex direction='column' gap='4'>
+                {newChannelType === 'Private' && <Flex direction='column' gap='4'>
                     <Text size='2'>Please understand that when you make <strong>{channelData?.channel_name}</strong> a private channel:</Text>
                     <ul className={'list-inside'}>
                         <li><Text size='1'>No changes will be made to the channel's history or members</Text></li>
                         <li><Text size='1'>All files shared in this channel will become private and will be accessible only to the channel members</Text></li>
+                    </ul>
+                </Flex>}
+                {newChannelType === 'Open' && <Flex direction='column' gap='4'>
+                    <Text size='2'>Please understand that when you make <strong>{channelData?.channel_name}</strong> a open channel:</Text>
+                    <ul className={'list-inside'}>
+                        <li><Text size='1'>Everyone from your organisation will become a channel member and will be able to view its message history.</Text></li>
+                        <li><Text size='1'>If you later intend to make this private you will have to manually remove members that should not have access to this channel.</Text></li>
                     </ul>
                 </Flex>}
             </Flex>
@@ -55,9 +64,9 @@ export const ChangeChannelTypeModal = ({ onClose, channelData }: ChangeChannelTy
                 <Dialog.Close disabled={updatingDoc}>
                     <Button variant="soft" color="gray">Cancel</Button>
                 </Dialog.Close>
-                <Button onClick={() => changeChannelType(new_channel_type)} disabled={updatingDoc}>
+                <Button onClick={() => changeChannelType(newChannelType)} disabled={updatingDoc}>
                     {updatingDoc && <Loader />}
-                    {updatingDoc ? "Saving" : `Change to ${new_channel_type.toLocaleLowerCase()}`}
+                    {updatingDoc ? "Saving" : `Change to ${newChannelType.toLocaleLowerCase()}`}
                 </Button>
             </Flex>
         </>


### PR DESCRIPTION
<img width="1512" alt="Screenshot 2024-04-07 at 9 39 35 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/a34faf4a-94a6-4107-ac9c-4f68105d7059">

<img width="1512" alt="Screenshot 2024-04-07 at 9 39 47 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/a0edcc78-0827-4d32-a962-69a82405fb4a">

If you are a channel admin, you get the ability to change the channel type:
Open can be converted to Public or Private
Private can be converted to Open or Public
Public can be converted to Private or Open