### PR TITLE
fix(web): upload files on hitting enter

### DIFF
--- a/raven-app/src/components/feature/chat/ChatInput/FileInput/useFileUpload.ts
+++ b/raven-app/src/components/feature/chat/ChatInput/FileInput/useFileUpload.ts
@@ -16,6 +16,10 @@ export default function useFileUpload(channelID: string, selectedMessage?: Messa
 
   const [files, setFiles] = useState<CustomFile[]>([])
 
+  const filesStateRef = useRef<CustomFile[]>([])
+
+  filesStateRef.current = files
+
   const [fileUploadProgress, setFileUploadProgress] = useState<Record<string, FileUploadProgress>>({})
 
   const addFile = (file: File) => {
@@ -38,7 +42,7 @@ export default function useFileUpload(channelID: string, selectedMessage?: Messa
   }
 
   const uploadFiles = async () => {
-    const newFiles = [...files]
+    const newFiles = [...filesStateRef.current]
     if (newFiles.length > 0) {
       const promises = newFiles.map(async (f: CustomFile) => {
         return file.uploadFile(f,

--- a/raven-app/yarn.lock
+++ b/raven-app/yarn.lock
@@ -4800,6 +4800,7 @@ sourcemap-codec@^1.4.8:
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4873,6 +4874,7 @@ stringify-object@^3.3.0:
     is-regexp "^1.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Was an easy fix:

Callback function passed to Tiptap has a state dependency. If the callback was added as a dependency to Tiptap's `useEditor` hook, it would cause rerenders (and hence also lose focus).

Solution:
Just store the file array in a ref