### PR TITLE
fix: consistent font sizes and icon alignment

### DIFF
--- a/raven-app/src/components/feature/channels/ChannelList.tsx
+++ b/raven-app/src/components/feature/channels/ChannelList.tsx
@@ -19,7 +19,7 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
 
     return (
         <SidebarGroup>
-            <SidebarGroupItem className={'pl-0.5 gap-0.5'}>
+            <SidebarGroupItem className={'pl-1.5 gap-1.5'}>
                 <SidebarViewMoreButton onClick={toggle} />
                 <Flex width='100%' justify='between' align='center' gap='2'>
                     <Flex gap='2' align='center'>

--- a/raven-app/src/components/feature/channels/ChannelList.tsx
+++ b/raven-app/src/components/feature/channels/ChannelList.tsx
@@ -19,7 +19,7 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
 
     return (
         <SidebarGroup>
-            <SidebarGroupItem gap='2' className={'pl-1.5'}>
+            <SidebarGroupItem className={'pl-0.5 gap-0.5'}>
                 <SidebarViewMoreButton onClick={toggle} />
                 <Flex width='100%' justify='between' align='center' gap='2'>
                     <Flex gap='2' align='center'>

--- a/raven-app/src/components/feature/channels/CreateChannelModal.tsx
+++ b/raven-app/src/components/feature/channels/CreateChannelModal.tsx
@@ -100,8 +100,8 @@ export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: 
 
     return <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
         <Dialog.Trigger>
-            <IconButton variant='ghost' size='1' color='gray' aria-label='Create Channel' className='h-[18px]' title='Create Channel'>
-                <BiPlus className='text-slate-12' />
+            <IconButton variant='ghost' size='1' color='gray' aria-label='Create Channel' title='Create Channel'>
+                <BiPlus className='text-slate-12 text-sm' />
             </IconButton>
         </Dialog.Trigger>
         <Dialog.Content className={DIALOG_CONTENT_CLASS}>

--- a/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -249,12 +249,12 @@ const Tiptap = ({ slotBefore, fileProps, onMessageSend, replyMessage, clearReply
             codeBlock: false,
             listItem: {
                 HTMLAttributes: {
-                    class: 'rt-Text'
+                    class: 'rt-Text text-sm'
                 }
             },
             paragraph: {
                 HTMLAttributes: {
-                    class: 'rt-Text'
+                    class: 'rt-Text text-sm'
                 }
             }
         }),

--- a/raven-app/src/components/feature/chat/ChatMessage/MessageItem.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/MessageItem.tsx
@@ -111,7 +111,7 @@ export const MessageItem = ({ message, setDeleteMessage, isHighlighted, onReplyM
                             <MessageContent
                                 message={message}
                                 user={user}
-                                className={clsx(message.is_continuation ? 'ml-0.5' : '')} />
+                            />
 
                             {message.link_doctype && message.link_document && <Box className={clsx(message.is_continuation ? 'ml-0.5' : '-ml-0.5')}>
                                 <DoctypeLinkRenderer doctype={message.link_doctype} docname={message.link_document} />

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/TiptapRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/TiptapRenderer.tsx
@@ -57,12 +57,12 @@ export const TiptapRenderer = ({ message, user, isScrolling = false, isTruncated
         italic: false,
         listItem: {
           HTMLAttributes: {
-            class: 'ml-5 rt-Text rt-r-size-2'
+            class: 'ml-5 rt-Text text-sm'
           }
         },
         paragraph: {
           HTMLAttributes: {
-            class: 'rt-Text rt-r-size-2'
+            class: 'rt-Text text-sm'
           }
         }
       }),

--- a/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -21,7 +21,7 @@ export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCount
 
     return (
         <SidebarGroup pb='4'>
-            <SidebarGroupItem className={'pl-0.5 gap-0.5'}>
+            <SidebarGroupItem className={'pl-1.5 gap-1.5'}>
                 <SidebarViewMoreButton onClick={toggle} />
                 <Flex width='100%' justify='between' align='center' gap='2'>
                     <SidebarGroupLabel className='cal-sans'>Direct Messages</SidebarGroupLabel>

--- a/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -21,12 +21,10 @@ export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCount
 
     return (
         <SidebarGroup pb='4'>
-            <SidebarGroupItem gap='2' className={'pl-1.5'}>
+            <SidebarGroupItem className={'pl-0.5 gap-0.5'}>
                 <SidebarViewMoreButton onClick={toggle} />
                 <Flex width='100%' justify='between' align='center' gap='2'>
-                    <Flex gap='2' align='center'>
-                        <SidebarGroupLabel className='cal-sans'>Direct Messages</SidebarGroupLabel>
-                    </Flex>
+                    <SidebarGroupLabel className='cal-sans'>Direct Messages</SidebarGroupLabel>
                     {!showData && unread_count && unread_count?.total_unread_count_in_dms > 0 &&
                         <Box pr='2'>
                             <SidebarBadge>{unread_count.total_unread_count_in_dms}</SidebarBadge>

--- a/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode, useState } from 'react'
 import { NavLink } from 'react-router-dom'
-import { Flex, IconButton, Text, Badge } from '@radix-ui/themes';
+import { Flex, IconButton, Text, Theme } from '@radix-ui/themes';
 import { FlexProps } from '@radix-ui/themes/dist/cjs/components/flex';
 import { TextProps } from '@radix-ui/themes/dist/cjs/components/text';
 import { IconButtonProps } from '@radix-ui/themes/dist/cjs/components/icon-button';
 import { BadgeProps } from '@radix-ui/themes/dist/cjs/components/badge';
 import { clsx } from 'clsx';
-import { BsCaretDownFill, BsCaretRightFill } from 'react-icons/bs';
+import { FaCaretDown, FaCaretRight } from 'react-icons/fa';
 
 interface SidebarGroupProps extends FlexProps {
     children: ReactNode;
@@ -145,14 +145,14 @@ export const SidebarViewMoreButton = ({ onClick, ...props }: SidebarViewMoreButt
             title='View'
             variant='ghost'
             size='1'
-            className='cursor-pointer text-slate-12 bg-transparent hover:text-gray-12'
+            className='cursor-pointer pb-[4px] text-slate-12 bg-transparent hover:text-gray-12'
             highContrast
             onClick={() => {
                 setIsViewMore(!isViewMore)
                 onClick()
             }}
             {...props}>
-            {isViewMore ? <BsCaretRightFill size='13' /> : <BsCaretDownFill size='13' />}
+            {isViewMore ? <FaCaretRight size='18' /> : <FaCaretDown size='18' />}
         </IconButton>
     )
 }
@@ -160,15 +160,14 @@ export const SidebarViewMoreButton = ({ onClick, ...props }: SidebarViewMoreButt
 export const SidebarBadge = ({ children, ...props }: BadgeProps) => {
 
     return (
-        <Badge
-            color='gray'
-            variant='solid'
-            size='1'
-            radius="large"
-            highContrast
-            {...props}
-        >
-            {children}
-        </Badge>
+        <Theme accentColor='gray'>
+            <div className='flex items-center justify-center dark:text-accent-a11 dark:bg-accent-a3 bg-accent-a4 text-xs py-0.5 px-2 rounded-radius2
+            whitespace-nowrap font-medium
+            '>
+                {children}
+            </div>
+        </Theme>
+
+
     )
 }

--- a/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
@@ -39,7 +39,7 @@ type SidebarGroupLabelProps = TextProps & {
 
 export const SidebarGroupLabel = ({ children, ...props }: SidebarGroupLabelProps) => {
     return (
-        <Text size='2' weight='medium' {...props}>
+        <Text size='2' {...props}>
             {children}
         </Text>
     )

--- a/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
@@ -67,7 +67,7 @@ interface SidebarItemProps extends FlexProps {
 
 export const SidebarItem = ({ to, children, end, active = false, activeStyles, className, ...props }: SidebarItemProps) => {
 
-    const activeClass = 'bg-[#EBEBEB] dark:bg-gray-6 text-gray-12'
+    const activeClass = 'bg-[#EBEBEB] dark:bg-gray-4 text-gray-12'
 
     return (
         <NavLink
@@ -81,7 +81,7 @@ export const SidebarItem = ({ to, children, end, active = false, activeStyles, c
                         gap='2'
                         align='center'
                         px='2'
-                        className={clsx('cursor-pointer text-black dark:text-gray-100 user-select-none rounded-md no-underline transition-all duration-200 hover:bg-gray-3 dark:hover:bg-gray-5', isActive ? activeClass : '', className)}
+                        className={clsx('cursor-pointer text-black dark:text-gray-100 user-select-none rounded-md no-underline transition-all duration-200 hover:bg-gray-3 dark:hover:bg-gray-3', isActive ? activeClass : '', className)}
                         {...props}>
                         {children}
                     </Flex>
@@ -161,7 +161,7 @@ export const SidebarBadge = ({ children, ...props }: BadgeProps) => {
 
     return (
         <Theme accentColor='gray'>
-            <div className='flex items-center justify-center dark:text-accent-a11 dark:bg-accent-a3 bg-accent-a4 text-xs py-0.5 px-2 rounded-radius2
+            <div className='flex items-center justify-center dark:text-accent-a12 dark:bg-accent-a3 bg-accent-a4 text-xs py-0.5 px-2 rounded-radius2
             whitespace-nowrap font-medium
             '>
                 {children}


### PR DESCRIPTION
1. Tightened up the spacing on the channel caret icon
2. Made the unread count badge less "important"
3. Fixed font size of editor

<img width="252" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/12d04e7c-1c25-47d4-b0d8-d64289f5988c">
<img width="252" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/4054ae0c-095d-4f61-8804-456c91114a64">
<img width="252" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/20163886-86db-40b2-b7bc-ac4a0391c8df">
<img width="925" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/d7e0edeb-54fe-4b6f-b39b-be0dcdc2eb55">


