### PR TITLE
fix: DM sorting by last message on mobile

### DIFF
--- a/mobile/src/pages/direct-messages/DirectMessageList.tsx
+++ b/mobile/src/pages/direct-messages/DirectMessageList.tsx
@@ -76,12 +76,9 @@ const useMessageUsersList = () => {
         })
 
         return usersWithChannels.sort((a, b) => {
-            if (a.channel && b.channel) {
-                const bTimestamp = b.channel.last_message_timestamp ? new Date(b.channel.last_message_timestamp).getTime() : 0
-                const aTimestamp = a.channel.last_message_timestamp ? new Date(a.channel.last_message_timestamp).getTime() : 0
-                return new Date(bTimestamp).getTime() - new Date(aTimestamp).getTime()
-            }
-            return 0
+            const bTimestamp = b.channel?.last_message_timestamp ? new Date(b.channel.last_message_timestamp).getTime() : 0
+            const aTimestamp = a.channel?.last_message_timestamp ? new Date(a.channel.last_message_timestamp).getTime() : 0
+            return bTimestamp - aTimestamp
         })
     }, [users, dm_channels])
 


### PR DESCRIPTION
Had a conditional that checked whether the DM user has a channel - hence sorting was broken.