### PR TITLE
feat: emoji suggestions

### DIFF
--- a/mobile/src/components/common/EmojiPicker.tsx
+++ b/mobile/src/components/common/EmojiPicker.tsx
@@ -2,12 +2,17 @@ import { createElement, useEffect, useRef } from "react"
 import 'emoji-picker-element'
 import './emojiPicker.styles.css'
 
+import { Database } from "emoji-picker-element";
+
+export const emojiDatabase = new Database();
+
 const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
 
     const ref = useRef<any>(null)
 
     useEffect(() => {
         const handler = (event: any) => {
+            emojiDatabase.incrementFavoriteEmojiCount(event.detail.unicode)
             onSelect(event.detail.unicode)
         }
         ref.current?.addEventListener('emoji-click', handler)

--- a/mobile/src/components/features/chat-input/EmojiList.tsx
+++ b/mobile/src/components/features/chat-input/EmojiList.tsx
@@ -1,0 +1,94 @@
+import { Text } from '@radix-ui/themes'
+import { ReactRendererOptions } from '@tiptap/react'
+import { NativeEmoji } from 'emoji-picker-element/shared'
+import {
+    forwardRef, useEffect, useImperativeHandle,
+    useState,
+} from 'react'
+
+export default forwardRef((props: ReactRendererOptions['props'], ref) => {
+
+    const [selectedIndex, setSelectedIndex] = useState(0)
+
+    const selectItem = (index: number) => {
+        const item = props?.items[index]
+        if (item) {
+            props.command(item)
+        }
+    }
+
+    const upHandler = () => {
+        setSelectedIndex((selectedIndex + props?.items.length - 1) % props?.items.length)
+    }
+
+    const downHandler = () => {
+        setSelectedIndex((selectedIndex + 1) % props?.items.length)
+    }
+
+    const enterHandler = () => {
+        selectItem(selectedIndex)
+    }
+
+    useEffect(() => setSelectedIndex(0), [props?.items])
+
+    useImperativeHandle(ref, () => ({
+        onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+            if (event.key === 'ArrowUp') {
+                upHandler()
+                return true
+            }
+
+            if (event.key === 'ArrowDown') {
+                downHandler()
+                return true
+            }
+
+            if (event.key === 'Enter') {
+                enterHandler()
+                return true
+            }
+
+            return false
+        },
+    }))
+
+    if (props?.items.length) {
+        return (
+            <ul role="list"
+                data-is-toolbar-element={true}
+                className="divide-y w-full divide-gray-5 overflow-x-hidden bg-gray-2 border border-gray-5 shadow-lg list-none rounded-md overflow-y-scroll max-h-72">
+                {props.items.map((item: NativeEmoji, index: number) => (
+                    <EmojiItem
+                        item={item}
+                        index={index}
+                        selectItem={selectItem}
+                        selectedIndex={selectedIndex}
+                        key={item.name}
+                        itemsLength={props.items.length}
+                    />
+                ))
+
+                }
+            </ul>
+        )
+    } else {
+        return null
+    }
+})
+
+const EmojiItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: NativeEmoji, selectItem: (index: number) => void }) => {
+
+    const roundedTop = index === 0 ? ' rounded-t-md' : ''
+
+    const roundedBottom = index === itemsLength - 1 ? ' rounded-b-md' : ''
+
+    return <li
+        data-is-toolbar-element={true}
+        className={'py-2 px-3 w-[90vw] text-md  active:bg-gray-4 focus:bg-gray-4 focus-visible:bg-gray-4 hover:bg-gray-4' + roundedBottom + roundedTop}
+        onClick={() => selectItem(index)}
+    >
+        <Text as='span' weight='medium' size='2' data-is-toolbar-element={true}>
+            {item.unicode} {item.shortcodes?.[0] ?? item.annotation}
+        </Text>
+    </li>
+}

--- a/mobile/src/components/features/chat-input/EmojiSuggestion.tsx
+++ b/mobile/src/components/features/chat-input/EmojiSuggestion.tsx
@@ -1,0 +1,104 @@
+import { Node } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import { ReactRenderer } from '@tiptap/react'
+import EmojiList from './EmojiList'
+import tippy from 'tippy.js';
+import { NativeEmoji } from 'emoji-picker-element/shared';
+import { PluginKey } from '@tiptap/pm/state';
+import { emojiDatabase } from '@/components/common/EmojiPicker';
+
+export const EmojiSuggestion = Node.create({
+    name: 'emoji',
+    group: 'inline',
+    pluginKey: new PluginKey('emojiSuggestion'),
+
+    inline: true,
+
+    selectable: false,
+
+    atom: true,
+
+    addProseMirrorPlugins() {
+        return [
+            Suggestion({
+                editor: this.editor,
+                char: ':',
+                items: (query) => {
+                    if (query.query.length !== 0) {
+                        return emojiDatabase.getEmojiBySearchQuery(query.query.toLowerCase()).then((emojis) => {
+                            return emojis.slice(0, 10) as NativeEmoji[]
+                        });
+                    } else {
+                        return emojiDatabase.getTopFavoriteEmoji(10) as Promise<NativeEmoji[]>
+                    }
+
+
+                    return []
+                },
+                render: () => {
+                    let component: any;
+                    let popup: any;
+
+                    return {
+                        onStart: props => {
+                            component = new ReactRenderer(EmojiList, {
+                                props,
+                                editor: props.editor,
+                            })
+
+                            if (!props.clientRect) {
+                                return
+                            }
+
+                            popup = tippy('body' as any, {
+                                getReferenceClientRect: props.clientRect as any,
+                                appendTo: () => document.body,
+                                content: component.element,
+                                showOnCreate: true,
+                                interactive: true,
+                                trigger: 'manual',
+                                placement: 'bottom-start',
+                            })
+                        },
+
+                        onUpdate(props) {
+                            component.updateProps(props)
+
+                            if (!props.clientRect) {
+                                return
+                            }
+
+                            popup[0].setProps({
+                                getReferenceClientRect: props.clientRect,
+                            })
+                        },
+
+                        onKeyDown(props) {
+                            if (props.event.key === 'Escape') {
+                                popup[0].hide()
+
+                                return true
+                            }
+
+                            return component.ref?.onKeyDown(props)
+                        },
+
+                        onExit() {
+                            popup[0].destroy()
+                            component.destroy()
+                        },
+                    }
+                },
+                command: ({ editor, range, props }) => {
+                    // Replace the text from : to with the emoji node
+                    editor.chain().focus().deleteRange(range).insertContent(props.unicode).run()
+
+                    emojiDatabase.incrementFavoriteEmojiCount(props.unicode)
+
+                    window.getSelection()?.collapseToEnd()
+                },
+            }),
+        ]
+    },
+
+})

--- a/mobile/src/components/features/chat-input/Tiptap.tsx
+++ b/mobile/src/components/features/chat-input/Tiptap.tsx
@@ -21,13 +21,13 @@ import ts from 'highlight.js/lib/languages/typescript'
 import html from 'highlight.js/lib/languages/xml'
 import json from 'highlight.js/lib/languages/json'
 import python from 'highlight.js/lib/languages/python'
-import { BiSend, BiSolidSend } from 'react-icons/bi'
-import { AiOutlinePaperClip } from 'react-icons/ai';
+import { BiSolidSend } from 'react-icons/bi'
 import { IconButton } from '@radix-ui/themes'
 import { useKeyboardState } from '@ionic/react-hooks/keyboard';
 import MessageInputActions from './MessageInputActions'
 import { useClickAway } from '@uidotdev/usehooks'
 import { FiPlus } from 'react-icons/fi'
+import { EmojiSuggestion } from './EmojiSuggestion'
 
 const lowlight = createLowlight(common)
 
@@ -109,7 +109,7 @@ export const Tiptap = ({ onMessageSend, messageSending, defaultText = '', onPick
             },
             code: {
                 HTMLAttributes: {
-                    class: 'font-mono bg-slate-950 text-sm radius-md p-1 text-white'
+                    class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
                 }
             },
 
@@ -273,6 +273,7 @@ export const Tiptap = ({ onMessageSend, messageSending, defaultText = '', onPick
         Placeholder.configure({
             placeholder: 'Type a message...'
         }),
+        EmojiSuggestion
     ]
 
     const [focused, setFocused] = useState(false)

--- a/mobile/src/components/features/chat-space/chat-view/components/TiptapRenderer/TiptapRenderer.tsx
+++ b/mobile/src/components/features/chat-space/chat-view/components/TiptapRenderer/TiptapRenderer.tsx
@@ -67,6 +67,11 @@ export const TiptapRenderer = ({ message, user, isScrolling = false, isTruncated
             class: 'pl-4 border-l-4 border-gray-500'
           }
         },
+        code: {
+          HTMLAttributes: {
+            class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
+          }
+        }
       }),
       Highlight.configure({
         multicolor: true,

--- a/raven-app/package.json
+++ b/raven-app/package.json
@@ -19,7 +19,6 @@
     "@tiptap/extension-placeholder": "^2.3",
     "@tiptap/extension-typography": "^2.3",
     "@tiptap/extension-underline": "^2.3",
-    "@tiptap/extension-code":"^2.3",
     "@tiptap/pm": "^2.3",
     "@tiptap/react": "^2.3",
     "@tiptap/starter-kit": "^2.3",

--- a/raven-app/src/components/common/EmojiPicker/EmojiPicker.tsx
+++ b/raven-app/src/components/common/EmojiPicker/EmojiPicker.tsx
@@ -2,6 +2,9 @@ import { createElement, useEffect, useRef } from "react"
 import 'emoji-picker-element'
 import './emojiPicker.styles.css'
 import { useTheme } from "@/ThemeProvider"
+import { Database } from "emoji-picker-element";
+
+export const emojiDatabase = new Database();
 
 const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
 
@@ -10,13 +13,14 @@ const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
 
     useEffect(() => {
         const handler = (event: any) => {
+            emojiDatabase.incrementFavoriteEmojiCount(event.detail.unicode)
             onSelect(event.detail.unicode)
         }
         ref.current?.addEventListener('emoji-click', handler)
         ref.current.skinToneEmoji = '👍'
 
         const style = document.createElement('style');
-        style.textContent = `.picker { border-radius: var(--radius-4); box-shadow: var(--shadow-6); } input.search{ color: ${appearance === 'light' ? '#020617' : '#f1f5f9' } }`
+        style.textContent = `.picker { border-radius: var(--radius-4); box-shadow: var(--shadow-6); } input.search{ color: ${appearance === 'light' ? '#020617' : '#f1f5f9'} }`
         ref.current.shadowRoot.appendChild(style);
 
         return () => {

--- a/raven-app/src/components/feature/chat/ChatInput/EmojiList.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput/EmojiList.tsx
@@ -1,0 +1,108 @@
+import { Flex, Text, Theme } from '@radix-ui/themes'
+import { ReactRendererOptions } from '@tiptap/react'
+import { clsx } from 'clsx'
+import { NativeEmoji } from 'emoji-picker-element/shared'
+import {
+    forwardRef, useEffect, useImperativeHandle,
+    useRef,
+    useState,
+} from 'react'
+
+export default forwardRef((props: ReactRendererOptions['props'], ref) => {
+
+    const [selectedIndex, setSelectedIndex] = useState(0)
+
+    const selectItem = (index: number) => {
+        const item = props?.items[index]
+
+        if (item) {
+            props.command(item)
+        }
+    }
+
+    const upHandler = () => {
+        setSelectedIndex((selectedIndex + props?.items.length - 1) % props?.items.length)
+    }
+
+    const downHandler = () => {
+        setSelectedIndex((selectedIndex + 1) % props?.items.length)
+    }
+
+    const enterHandler = () => {
+        selectItem(selectedIndex)
+    }
+
+    useEffect(() => setSelectedIndex(0), [props?.items])
+
+    useImperativeHandle(ref, () => ({
+        onKeyDown: ({ event }: { event: KeyboardEvent }) => {
+            if (event.key === 'ArrowUp') {
+                upHandler()
+                return true
+            }
+
+            if (event.key === 'ArrowDown') {
+                downHandler()
+                return true
+            }
+
+            if (event.key === 'Enter') {
+                enterHandler()
+                return true
+            }
+
+            return false
+        },
+    }))
+
+    return (
+        <Theme accentColor='iris' panelBackground='translucent'>
+            <Flex
+                direction='column'
+                gap='0'
+                className='shadow-lg dark:backdrop-blur-[8px] dark:bg-panel-translucent bg-white overflow-y-scroll max-h-96 rounded-md'
+            >
+                {props?.items.length
+                    ? props.items.map((item: NativeEmoji, index: number) => (
+                        <MentionItem
+                            item={item}
+                            index={index}
+                            selectItem={selectItem}
+                            selectedIndex={selectedIndex}
+                            key={item.annotation}
+                            itemsLength={props.items.length}
+                        />
+                    ))
+                    : null
+                }
+            </Flex>
+        </Theme>
+    )
+})
+
+const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: NativeEmoji, selectItem: (index: number) => void }) => {
+
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (index === selectedIndex) ref.current?.scrollIntoView({ block: 'nearest' })
+    }, [selectedIndex, index])
+
+
+    return <Flex
+        role='button'
+        ref={ref}
+        align='center'
+        title={item.annotation}
+        aria-label={`Select emoji ${item.annotation}`}
+        className={clsx('px-3 py-1.5 gap-2 rounded-md',
+            index === itemsLength - 1 ? 'rounded-b-md' : 'rounded-b-none',
+            index === 0 ? 'rounded-t-md' : 'rounded-t-none',
+            index === selectedIndex ? 'bg-accent-a5' : 'bg-panel-translucent'
+        )}
+        key={index}
+        onClick={() => selectItem(index)}
+    >
+        <Text as='span' weight='medium' size='2'>{item.unicode} {item.shortcodes?.[0] ?? item.annotation}</Text>
+    </Flex >
+}

--- a/raven-app/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
@@ -1,0 +1,104 @@
+import { Node } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+import { ReactRenderer } from '@tiptap/react'
+import EmojiList from './EmojiList'
+import tippy from 'tippy.js';
+import { NativeEmoji } from 'emoji-picker-element/shared';
+import { PluginKey } from '@tiptap/pm/state';
+import { emojiDatabase } from '@/components/common/EmojiPicker/EmojiPicker';
+
+export const EmojiSuggestion = Node.create({
+    name: 'emoji',
+    group: 'inline',
+    pluginKey: new PluginKey('emojiSuggestion'),
+
+    inline: true,
+
+    selectable: false,
+
+    atom: true,
+
+    addProseMirrorPlugins() {
+        return [
+            Suggestion({
+                editor: this.editor,
+                char: ':',
+                items: (query) => {
+                    if (query.query.length !== 0) {
+                        return emojiDatabase.getEmojiBySearchQuery(query.query.toLowerCase()).then((emojis) => {
+                            return emojis.slice(0, 10) as NativeEmoji[]
+                        });
+                    } else {
+                        return emojiDatabase.getTopFavoriteEmoji(10) as Promise<NativeEmoji[]>
+                    }
+
+
+                    return []
+                },
+                render: () => {
+                    let component: any;
+                    let popup: any;
+
+                    return {
+                        onStart: props => {
+                            component = new ReactRenderer(EmojiList, {
+                                props,
+                                editor: props.editor,
+                            })
+
+                            if (!props.clientRect) {
+                                return
+                            }
+
+                            popup = tippy('body' as any, {
+                                getReferenceClientRect: props.clientRect as any,
+                                appendTo: () => document.body,
+                                content: component.element,
+                                showOnCreate: true,
+                                interactive: true,
+                                trigger: 'manual',
+                                placement: 'bottom-start',
+                            })
+                        },
+
+                        onUpdate(props) {
+                            component.updateProps(props)
+
+                            if (!props.clientRect) {
+                                return
+                            }
+
+                            popup[0].setProps({
+                                getReferenceClientRect: props.clientRect,
+                            })
+                        },
+
+                        onKeyDown(props) {
+                            if (props.event.key === 'Escape') {
+                                popup[0].hide()
+
+                                return true
+                            }
+
+                            return component.ref?.onKeyDown(props)
+                        },
+
+                        onExit() {
+                            popup[0].destroy()
+                            component.destroy()
+                        },
+                    }
+                },
+                command: ({ editor, range, props }) => {
+                    // Replace the text from : to with the emoji node
+                    editor.chain().focus().deleteRange(range).insertContent(props.unicode).run()
+
+                    emojiDatabase.incrementFavoriteEmojiCount(props.unicode)
+
+                    window.getSelection()?.collapseToEnd()
+                },
+            }),
+        ]
+    },
+
+})

--- a/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/raven-app/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -30,6 +30,7 @@ import { Box } from '@radix-ui/themes'
 import { useSessionStickyState } from '@/hooks/useStickyState'
 import { Message } from '../../../../../../types/Messaging/Message'
 import Image from '@tiptap/extension-image'
+import { EmojiSuggestion } from './EmojiSuggestion'
 const lowlight = createLowlight(common)
 
 lowlight.register('html', html)
@@ -75,6 +76,7 @@ export const ChannelMention = Mention.extend({
             pluginKey: new PluginKey('channelMention'),
         }
     })
+
 const Tiptap = ({ slotBefore, fileProps, onMessageSend, replyMessage, clearReplyMessage, placeholder = 'Type a message...', messageSending, sessionStorageKey = 'tiptap-editor', disableSessionStorage = false, defaultText = '' }: TiptapEditorProps) => {
 
     const { enabledUsers } = useContext(UserListContext)
@@ -91,13 +93,9 @@ const Tiptap = ({ slotBefore, fileProps, onMessageSend, replyMessage, clearReply
                     const isCodeBlockActive = this.editor.isActive('codeBlock');
                     const isListItemActive = this.editor.isActive('listItem');
 
-
-                    // FIXME: This breaks sometimes when the key is not `userMention$` but a random number appended in front of it
-                    //@ts-expect-error
-                    const isSuggestionOpen = this.editor.state.userMention$?.active || this.editor.state.channelMention$?.active
                     const hasContent = this.editor.getText().trim().length > 0
 
-                    if (isCodeBlockActive || isListItemActive || isSuggestionOpen) {
+                    if (isCodeBlockActive || isListItemActive) {
                         return false;
                     }
                     let html = ''
@@ -252,8 +250,43 @@ const Tiptap = ({ slotBefore, fileProps, onMessageSend, replyMessage, clearReply
                 HTMLAttributes: {
                     class: 'rt-Text text-sm'
                 }
+            },
+            code: {
+                HTMLAttributes: {
+                    class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
+                }
+            },
+        }),
+        Underline,
+        Highlight.configure({
+            multicolor: true,
+            HTMLAttributes: {
+                class: 'bg-[var(--yellow-6)] dark:bg-[var(--yellow-11)] px-2 py-1'
             }
         }),
+        Link.extend({ inclusive: false }).configure({
+            autolink: true,
+            protocols: ['mailto', 'https', 'http'],
+        }),
+        Placeholder.configure({
+            // Pick a random placeholder from the list.
+            placeholder,
+        }),
+        CodeBlockLowlight.extend({
+            addKeyboardShortcuts() {
+                return {
+                    // this extends existing shortcuts instead of overwriting
+                    ...this.parent?.(),
+                    'Mod-Shift-E': () => this.editor.commands.toggleCodeBlock(),
+                }
+            }
+        }).configure({
+            lowlight
+        }),
+        Image.configure({
+            inline: true,
+        }),
+        KeyboardHandler,
         UserMention.configure({
             HTMLAttributes: {
                 class: 'mention',
@@ -394,44 +427,7 @@ const Tiptap = ({ slotBefore, fileProps, onMessageSend, replyMessage, clearReply
 
             }
         }),
-        Underline,
-        Highlight.configure({
-            multicolor: true,
-            HTMLAttributes: {
-                class: 'bg-[var(--yellow-6)] dark:bg-[var(--yellow-11)] px-2 py-1'
-            }
-        }),
-        Link.extend({ inclusive: false }).configure({
-            autolink: true,
-            protocols: ['mailto', 'https', 'http'],
-        }),
-        Placeholder.configure({
-            // Pick a random placeholder from the list.
-            placeholder,
-        }),
-        CodeBlockLowlight.extend({
-            addKeyboardShortcuts() {
-                return {
-                    // this extends existing shortcuts instead of overwriting
-                    ...this.parent?.(),
-                    'Mod-Shift-E': () => this.editor.commands.toggleCodeBlock(),
-                }
-            }
-        }).configure({
-            lowlight
-        }),
-        CodeBlockLowlight.configure({
-            lowlight
-        }),
-        Code.configure({
-            HTMLAttributes: {
-                class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
-            }
-        }),
-        Image.configure({
-            inline: true,
-        }),
-        KeyboardHandler
+        EmojiSuggestion
     ]
 
     const [content, setContent] = useSessionStickyState(defaultText, sessionStorageKey, disableSessionStorage)

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/TiptapRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/TiptapRenderer.tsx
@@ -11,7 +11,6 @@ import ts from 'highlight.js/lib/languages/typescript'
 import html from 'highlight.js/lib/languages/xml'
 import json from 'highlight.js/lib/languages/json'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
-import Code from '@tiptap/extension-code'
 import { common, createLowlight } from 'lowlight'
 import python from 'highlight.js/lib/languages/python'
 import { CustomBold } from './Bold'
@@ -64,6 +63,11 @@ export const TiptapRenderer = ({ message, user, isScrolling = false, isTruncated
           HTMLAttributes: {
             class: 'rt-Text text-sm'
           }
+        },
+        code: {
+          HTMLAttributes: {
+            class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
+          }
         }
       }),
       Highlight.configure({
@@ -75,11 +79,6 @@ export const TiptapRenderer = ({ message, user, isScrolling = false, isTruncated
       CustomUnderline,
       CodeBlockLowlight.configure({
         lowlight
-      }),
-      Code.configure({
-        HTMLAttributes:{
-            class: 'pt-0.5 px-1 pb-px bg-[var(--gray-a3)] dark:bg-[#0d0d0d] text-[var(--ruby-a11)] dark-[var(--accent-a3)] text text-xs font-mono rounded border border-gray-4 dark:border-gray-6'
-        }
       }),
       CustomBold,
       CustomUserMention,

--- a/raven-app/yarn.lock
+++ b/raven-app/yarn.lock
@@ -2117,7 +2117,7 @@
   resolved "https://registry.yarnpkg.com/@tiptap/extension-code-block/-/extension-code-block-2.3.0.tgz#9bfaaeaf6abf2452233d1da64b6c5712cab2503b"
   integrity sha512-+Ne6PRBwQt70Pp8aW2PewaEy4bHrNYn4N+y8MObsFtqLutXBz4nXnsXWiNYFQZwzlUY+CHG4XS73mx8oMOFfDw==
 
-"@tiptap/extension-code@^2.3", "@tiptap/extension-code@^2.3.0":
+"@tiptap/extension-code@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@tiptap/extension-code/-/extension-code-2.3.0.tgz#19b5435c59021f11e24ac8427da4434b03596b35"
   integrity sha512-O2FZmosiIRoVbW82fZy8xW4h4gb2xAzxWzHEcsHPlwCbE3vYvcBMmbkQ5p+33eRtuRQInzl3Q/cwupv9ctIepQ==


### PR DESCRIPTION
Added support for emoji suggestions via the `:` key. This is available on both web and mobile.

<img width="1508" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/c23b0404-06df-41c7-9fd7-6a234236a902">


By default, on typing ":", we show frequently used emojis. The emojis are fetched from the same database (emoji-picker-element), so anytime a new emoji is selected (either from suggestions, or from the emoji picker (button/reactions)), we increment the count of it's usage. This data is maintained in IndexedDB by emoji-picker-element - hence not shared across browsers.

Also fixed a bug (regression of #869) where the code and code block plugins were initialised multiple times. 

This PR also fixes a FIXME added earlier related to the keyboard handler extension conflicting with the mention extensions. Simply reordering the extensions in the editor initialisation fixed the issue. 

