### PR TITLE
fix(ui): changed layout of sidebar with transitions

### DIFF
--- a/raven-app/src/components/feature/channels/ChannelList.tsx
+++ b/raven-app/src/components/feature/channels/ChannelList.tsx
@@ -1,7 +1,7 @@
 import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList, SidebarItem } from "../../layout/Sidebar"
 import { SidebarBadge, SidebarViewMoreButton } from "../../layout/Sidebar/SidebarComp"
 import { CreateChannelButton } from "./CreateChannelModal"
-import { useContext, useMemo } from "react"
+import { useContext, useMemo, useRef } from "react"
 import { ChannelListContext, ChannelListContextType, ChannelListItem, UnreadCountData } from "../../../utils/channel/ChannelListProvider"
 import { ChannelIcon } from "@/utils/layout/channelIcon"
 import { Box, ContextMenu, Flex, Text } from "@radix-ui/themes"
@@ -11,6 +11,7 @@ import useCurrentRavenUser from "@/hooks/useCurrentRavenUser"
 import { RiPushpinLine, RiUnpinLine } from "react-icons/ri"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { RavenUser } from "@/types/Raven/RavenUser"
+import clsx from "clsx"
 
 export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -51,26 +52,40 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
         }
     }, [channels, myProfile, unread_count])
 
+    const ref = useRef<HTMLDivElement>(null)
+
+    const height = ref.current?.clientHeight
+
     return (
         <SidebarGroup>
             <SidebarGroupItem className={'gap-1'}>
-                <SidebarViewMoreButton onClick={toggle} expanded={showData} />
-                <Flex width='100%' justify='between' align='center' gap='2'>
-                    <Flex gap='2' align='center'>
-                        <SidebarGroupLabel className='cal-sans text-gray-12 dark:text-gray-300'>Channels</SidebarGroupLabel>
-                        <CreateChannelButton updateChannelList={mutate} />
+                <Flex width='100%' justify='between' align='center' gap='2' className="group">
+                    <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
+                        <SidebarGroupLabel>Channels</SidebarGroupLabel>
+                        <Box className={clsx('transition-opacity ease-in-out duration-200',
+                            !showData && unread_count && totalUnreadCount > 0 ? 'opacity-100' : 'opacity-0')}>
+                            <SidebarBadge>
+                                {totalUnreadCount}
+                            </SidebarBadge>
+                        </Box>
                     </Flex>
-                    {!showData && unread_count && totalUnreadCount > 0 &&
-                        <Box pr='2'>
-                            <SidebarBadge>{totalUnreadCount}</SidebarBadge>
-                        </Box>}
+                    <Flex gap='2'>
+                        <CreateChannelButton updateChannelList={mutate} />
+                        <SidebarViewMoreButton onClick={toggle} expanded={showData} />
+                    </Flex>
                 </Flex>
             </SidebarGroupItem>
             <SidebarGroup>
-                <SidebarGroupList>
-                    {showData && filteredChannels.map((channel) => <ChannelItem
-                        channel={channel}
-                        key={channel.name} />)}
+                <SidebarGroupList
+                    style={{
+                        height: showData ? height : 0
+                    }}
+                >
+                    <div ref={ref} className="flex gap-1 flex-col">
+                        {filteredChannels.map((channel) => <ChannelItem
+                            channel={channel}
+                            key={channel.name} />)}
+                    </div>
                 </SidebarGroupList>
             </SidebarGroup>
         </SidebarGroup>

--- a/raven-app/src/components/feature/channels/CreateChannelModal.tsx
+++ b/raven-app/src/components/feature/channels/CreateChannelModal.tsx
@@ -5,11 +5,11 @@ import { BiGlobe, BiHash, BiLockAlt } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
 import { ErrorBanner } from '../../layout/AlertBanner'
 import { Box, Button, Dialog, Flex, IconButton, RadioGroup, Text, TextArea, TextField } from '@radix-ui/themes'
-import { BiPlus } from 'react-icons/bi'
 import { ErrorText, HelperText, Label } from '@/components/common/Form'
 import { Loader } from '@/components/common/Loader'
 import { DIALOG_CONTENT_CLASS } from '@/utils/layout/dialog'
 import { toast } from 'sonner'
+import { FiPlus } from 'react-icons/fi'
 
 interface ChannelCreationForm {
     channel_name: string,
@@ -93,8 +93,10 @@ export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: 
 
     return <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
         <Dialog.Trigger>
-            <IconButton variant='ghost' size='1' color='gray' aria-label='Create Channel' title='Create Channel'>
-                <BiPlus className='text-gray-12 dark:text-gray-300 text-md' />
+            <IconButton variant='soft' size='1' radius='large' color='gray' aria-label='Create Channel' title='Create Channel'
+                className='group-hover:visible invisible bg-transparent hover:bg-gray-3 transition-all ease-in-out text-gray-10 dark:text-gray-300'>
+                <FiPlus size='18' />
+                {/* <BiPlus className='text-gray-10 dark:text-gray-300' /> */}
             </IconButton>
         </Dialog.Trigger>
         <Dialog.Content className={DIALOG_CONTENT_CLASS}>

--- a/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/raven-app/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -1,5 +1,5 @@
 import { useFrappePostCall } from "frappe-react-sdk"
-import { useContext, useMemo, useState } from "react"
+import { useContext, useMemo, useRef, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList, SidebarIcon, SidebarButtonItem } from "../../layout/Sidebar"
 import { SidebarBadge, SidebarItem, SidebarViewMoreButton } from "../../layout/Sidebar/SidebarComp"
@@ -12,6 +12,7 @@ import { UserAvatar } from "@/components/common/UserAvatar"
 import { toast } from "sonner"
 import { getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
 import { useStickyState } from "@/hooks/useStickyState"
+import clsx from "clsx"
 
 export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -21,26 +22,33 @@ export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCount
 
     const toggle = () => setShowData(d => !d)
 
+    const ref = useRef<HTMLDivElement>(null)
+
+    const height = ref.current?.clientHeight
+
     return (
         <SidebarGroup pb='4'>
             <SidebarGroupItem className={'gap-1'}>
-                <SidebarViewMoreButton onClick={toggle} expanded={showData} />
-                <Flex width='100%' justify='between' align='center' gap='2'>
-                    <SidebarGroupLabel className='cal-sans text-gray-12 dark:text-gray-11'>Direct Messages</SidebarGroupLabel>
-                    {!showData && unread_count && unread_count?.total_unread_count_in_dms > 0 &&
-                        <Box pr='2'>
-                            <SidebarBadge>{unread_count.total_unread_count_in_dms}</SidebarBadge>
+                <Flex width='100%' justify='between' align='center' gap='2' pr='2' className="group">
+                    <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
+                        <SidebarGroupLabel>Members</SidebarGroupLabel>
+                        <Box className={clsx('transition-opacity ease-in-out duration-200', !showData && unread_count && unread_count?.total_unread_count_in_dms > 0 ? 'opacity-100' : 'opacity-0')}>
+                            <SidebarBadge>{unread_count?.total_unread_count_in_dms}</SidebarBadge>
                         </Box>
-                    }
+                    </Flex>
+                    <SidebarViewMoreButton onClick={toggle} expanded={showData} />
                 </Flex>
             </SidebarGroupItem>
             <SidebarGroup>
-                {showData &&
-                    <SidebarGroupList>
+                <SidebarGroupList
+                    style={{
+                        height: showData ? height : 0
+                    }}>
+                    <div ref={ref} className="flex gap-1 flex-col">
                         <DirectMessageItemList unread_count={unread_count} />
                         {extra_users && extra_users.length ? <ExtraUsersItemList /> : null}
-                    </SidebarGroupList>
-                }
+                    </div>
+                </SidebarGroupList>
             </SidebarGroup>
         </SidebarGroup>
     )

--- a/raven-app/src/components/layout/Sidebar/PinnedChannels.tsx
+++ b/raven-app/src/components/layout/Sidebar/PinnedChannels.tsx
@@ -4,7 +4,6 @@ import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList } f
 import { Box, Flex } from '@radix-ui/themes'
 import { ChannelItemElement } from '@/components/feature/channels/ChannelList'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
-import { RiPushpinFill } from 'react-icons/ri'
 
 const PinnedChannels = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -37,12 +36,9 @@ const PinnedChannels = ({ unread_count }: { unread_count?: UnreadCountData }) =>
 
     return (
         <Box>
-            <SidebarGroup pt='1'>
-                <SidebarGroupItem gap='2' className={'pl-0.5'}>
-                    <RiPushpinFill className='mt-0.5 text-gray-12 dark:text-gray-300' size='16' />
-                    <Flex width='100%' justify='between' align='center' gap='2'>
-                        <SidebarGroupLabel className='cal-sans text-gray-12 dark:text-gray-11'>Pinned</SidebarGroupLabel>
-                    </Flex>
+            <SidebarGroup>
+                <SidebarGroupItem className={'gap-1'}>
+                    <SidebarGroupLabel className='cal-sans'>Pinned</SidebarGroupLabel>
                 </SidebarGroupItem>
                 <SidebarGroup>
                     <SidebarGroupList>

--- a/raven-app/src/components/layout/Sidebar/SidebarBody.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarBody.tsx
@@ -12,7 +12,7 @@ export const SidebarBody = () => {
 
     return (
         <ScrollArea type="hover" scrollbars="vertical" className='h-[calc(100vh-7rem)]'>
-            <Flex direction='column' gap='4' className='overflow-x-hidden' px='2'>
+            <Flex direction='column' gap='3' className='overflow-x-hidden' px='2'>
                 <Flex direction='column' gap='2'>
                     <Box>
                         <SidebarItem to={'saved-messages'} className='py-1 px-0.5'>
@@ -20,13 +20,12 @@ export const SidebarBody = () => {
                                 <BiSolidBookmark className='text-gray-12 dark:text-gray-300 mt-0.5' size='14' />
                             </AccessibleIcon>
                             <Box>
-                                <Text size='2' className='cal-sans text-gray-12 dark:text-gray-300'>Saved</Text>
+                                <Text size='2' weight='bold' className='text-gray-12 dark:text-gray-300'>Saved</Text>
                             </Box>
                         </SidebarItem>
                     </Box>
                     <PinnedChannels unread_count={unread_count?.message} />
                 </Flex>
-
                 <ChannelList unread_count={unread_count?.message} />
                 <DirectMessageList unread_count={unread_count?.message} />
             </Flex>

--- a/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarComp.tsx
@@ -6,7 +6,7 @@ import { TextProps } from '@radix-ui/themes/dist/cjs/components/text';
 import { IconButtonProps } from '@radix-ui/themes/dist/cjs/components/icon-button';
 import { BadgeProps } from '@radix-ui/themes/dist/cjs/components/badge';
 import { clsx } from 'clsx';
-import { FaCaretDown, FaCaretRight } from 'react-icons/fa';
+import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
 
 interface SidebarGroupProps extends FlexProps {
     children: ReactNode;
@@ -39,7 +39,7 @@ type SidebarGroupLabelProps = TextProps & {
 
 export const SidebarGroupLabel = ({ children, ...props }: SidebarGroupLabelProps) => {
     return (
-        <Text size='2' {...props} className={clsx('text-gray-12 dark:text-gray-300', props.className)}>
+        <Text size='2' weight='bold' {...props} className={clsx('cal-sans text-gray-12 dark:text-gray-300', props.className)}>
             {children}
         </Text>
     )
@@ -51,7 +51,7 @@ interface SidebarGroupListProps extends FlexProps {
 export const SidebarGroupList = ({ children, ...props }: SidebarGroupListProps) => {
 
     return (
-        <Flex gap='1' direction='column' {...props}>
+        <Flex gap='1' direction='column' {...props} className={clsx(`transition-all ease-in-out duration-200 overflow-hidden`, props.className)}>
             {children}
         </Flex>
     )
@@ -140,15 +140,16 @@ export const SidebarViewMoreButton = ({ expanded, onClick, ...props }: SidebarVi
 
     return (
         <IconButton
-            aria-label={"view"}
-            title='View'
-            variant='ghost'
+            aria-label={expanded ? 'Collapse' : "Expand"}
+            title={expanded ? 'Collapse' : "Expand"}
+            variant='soft'
             size='1'
-            className='cursor-pointer pb-[3px] text-gray-12 dark:text-gray-300 bg-transparent'
-            highContrast
+            radius='large'
             onClick={onClick}
-            {...props}>
-            {expanded ? <FaCaretDown size='18' /> : <FaCaretRight size='18' />}
+            {...props}
+            className={clsx('cursor-pointer transition-all text-gray-10 dark:text-gray-300 bg-transparent hover:bg-gray-3 invisible group-hover:visible ease-in-out')}
+        >
+            {expanded ? <FiChevronDown /> : <FiChevronRight />}
         </IconButton>
     )
 }
@@ -157,7 +158,7 @@ export const SidebarBadge = ({ children, ...props }: BadgeProps) => {
 
     return (
         <Theme accentColor='gray'>
-            <div className='flex items-center justify-center dark:text-accent-a12 dark:bg-accent-a3 bg-accent-a4 text-xs py-0.5 px-2 rounded-radius2
+            <div className='flex items-center justify-center min-w-2 text-accent-a11 dark:text-accent-a11 dark:bg-accent-a3 bg-accent-a4 text-xs py-0.5 px-2 rounded-radius2
             whitespace-nowrap font-medium
             '>
                 {children}


### PR DESCRIPTION
The sidebar was too "crowded". Too many icons - and always shown.

1. Expand and collapse buttons are only shown on hover and are moved to the right.
2. Add button is also moved to the right - and only shown on hover
3. Clicking on "Channels" or "Members" also toggles the list
4. Removed icon for pinned messages
5. Added animation for collapsing and expanding groups (will be used when we add channel groups as well)
6. Transition added for unread count badge

Before:
<img width="260" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/78617806-86d7-4d11-b493-2bf875e41dfc">

After:
<img width="260" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/19825455/0541006d-f6d4-49a0-bc74-b1ff2ee66391">