### PR TITLE
fix: added temp events for desk interface

### DIFF
--- a/raven/api/raven_message.py
+++ b/raven/api/raven_message.py
@@ -7,7 +7,7 @@ from frappe.query_builder import Case, JoinType, Order
 from frappe.query_builder.functions import Coalesce, Count
 
 from raven.api.raven_channel import get_peer_user_id
-from raven.utils import get_channel_member
+from raven.utils import get_channel_member, track_channel_visit
 
 
 @frappe.whitelist(methods=["POST"])
@@ -200,6 +200,7 @@ def check_permission(channel_id):
 def get_messages_with_dates(channel_id):
 	check_permission(channel_id)
 	messages = get_messages(channel_id)
+	track_channel_visit(channel_id=channel_id, publish_event_for_user=True, commit=True)
 	return parse_messages(messages)
 
 

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -348,7 +348,28 @@ class RavenMessage(Document):
 		if self.message_type == "Poll":
 			frappe.delete_doc("Raven Poll", self.poll_id)
 
+		# TEMP: this is a temp fix for the Desk interface
+		self.publish_deprecated_event_for_desk()
+
+	def publish_deprecated_event_for_desk(self):
+		# TEMP: this is a temp fix for the Desk interface
+		frappe.publish_realtime(
+			"message_updated",
+			{
+				"channel_id": self.channel_id,
+				"sender": frappe.session.user,
+				"message_id": self.name,
+			},
+			doctype="Raven Channel",
+			docname=self.channel_id,
+			after_commit=True,
+		)
+
 	def on_update(self):
+
+		# TEMP: this is a temp fix for the Desk interface
+		self.publish_deprecated_event_for_desk()
+
 		if self.is_edited:
 			frappe.publish_realtime(
 				"message_edited",


### PR DESCRIPTION
Publish temp socket events for the desk interface. Will remove them once Desk interface integration has been updated.

Closes #905 