### PR TITLE
perf: cache user list

### DIFF
--- a/raven-app/src/utils/users/UserListProvider.tsx
+++ b/raven-app/src/utils/users/UserListProvider.tsx
@@ -22,6 +22,9 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
         revalidateOnReconnect: false,
     })
 
+    /** TODO: If a bulk import happens, this gets called multiple times potentially causing the server to go down.
+     * Instead, throttle this - wait for all events to subside
+     */
     useFrappeDocTypeEventListener('Raven User', () => {
         mutate()
 

--- a/raven/api/raven_users.py
+++ b/raven/api/raven_users.py
@@ -2,6 +2,7 @@ import json
 
 import frappe
 from frappe import _
+from frappe.utils.caching import redis_cache
 
 
 @frappe.whitelist(methods=["GET"])
@@ -12,7 +13,7 @@ def get_current_raven_user():
 
 	# Check if the user is a Raven User and has he "Raven User" role
 	# If not, then throw an error
-	if "Raven User" not in frappe.get_roles():
+	if not frappe.has_permission("Raven User"):
 		frappe.throw(
 			_(
 				"You do not have a <b>Raven User</b> role. Please contact your administrator to add your user profile as a <b>Raven User</b>."
@@ -23,7 +24,8 @@ def get_current_raven_user():
 	return frappe.get_cached_doc("Raven User", {"user": frappe.session.user})
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
+@frappe.read_only()
 def get_list():
 	"""
 	Fetches list of all users who have the role: Raven User
@@ -31,7 +33,7 @@ def get_list():
 
 	# Check if the user is a Raven User and has he "Raven User" role
 	# If not, then throw an error
-	if "Raven User" not in frappe.get_roles():
+	if not frappe.has_permission("Raven User"):
 		frappe.throw(
 			_(
 				"You do not have a <b>Raven User</b> role. Please contact your administrator to add your user profile as a <b>Raven User</b>."
@@ -39,14 +41,12 @@ def get_list():
 			title=_("Insufficient permissions. Please contact your administrator."),
 		)
 
-	if not frappe.db.exists("Raven User", {"user": frappe.session.user}):
-		frappe.throw(
-			_(
-				"You do not have a <b>Raven User</b> profile. Please contact your administrator to add your user profile as a <b>Raven User</b>."
-			),
-			title=_("Insufficient permissions. Please contact your administrator."),
-		)
+	# Get users is cached since this won't change frequently
+	return get_users()
 
+
+@redis_cache()
+def get_users():
 	users = frappe.db.get_all(
 		"Raven User",
 		fields=["full_name", "user_image", "name", "first_name", "enabled", "type"],

--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -50,6 +50,12 @@ class RavenUser(Document):
 		if self.type != "Bot":
 			self.update_photo_from_user()
 
+	def after_insert(self):
+		self.invalidate_user_list_cache()
+
+	def on_update(self):
+		self.invalidate_user_list_cache()
+
 	def on_trash(self):
 		"""
 		Remove the Raven User from all channels
@@ -65,6 +71,14 @@ class RavenUser(Document):
 		user.flags.deleting_raven_user = True
 		user.remove_roles("Raven User")
 		user.save()
+
+		self.invalidate_user_list_cache()
+
+	def invalidate_user_list_cache(self):
+
+		from raven.api.raven_users import get_users
+
+		get_users.clear_cache()
 
 	def update_photo_from_user(self):
 		"""


### PR DESCRIPTION
User List is cached on Redis.

Fetching 3524 Raven Users via `raven_users.get_list` API (averages over 10 runs)

Before: 120ms 
After: 20ms

Savings per request here does not matter as much but multiple concurrent users trying to access Raven at the same time will not hit the database to fetch the same list of users.


