### PR TITLE
fix: Removed the mail-id of user shown while viewing the Poll Votes.

### DIFF
--- a/mobile/src/components/features/polls/ViewPollVotes.tsx
+++ b/mobile/src/components/features/polls/ViewPollVotes.tsx
@@ -96,7 +96,6 @@ const UserVote = ({ user_id }: { user_id: string }) => {
         <IonLabel>
             <div className='flex flex-col -gap-0.5 text-ellipsis justify-center'>
                 <Text as='span' className='block' weight='medium' size='3'>{user?.full_name}</Text>
-                <Text as='span' size='2' color='gray'>{user?.name}</Text>
             </div>
         </IonLabel>
     </IonItem>

--- a/raven-app/src/components/feature/polls/ViewPollVotes.tsx
+++ b/raven-app/src/components/feature/polls/ViewPollVotes.tsx
@@ -117,7 +117,6 @@ const UserVote = ({ user_id }: { user_id: string }) => {
         <UserAvatar alt={user?.full_name} src={user?.user_image} size='2' />
         <div className='flex flex-col text-ellipsis justify-center border-b border-gray-6 w-full pb-2 group-last:pb-0 group-last:border-b-0'>
             <Text as='span' className='block' weight='medium' size='2'>{user?.full_name}</Text>
-            <Text as='span' size='1' color='gray'>{user?.name}</Text>
         </div>
     </Flex>
 }


### PR DESCRIPTION
**Introduction:**
Hello everyone! This is my first contribution to the project, and I'm thrilled to be part of this community.

**Purpose:**
I've fixed the bug issue of showing mail-id of users while viewing Poll Votes

**Description of Changes:**
- Removed line no 120 on ViewPollVotes.tsx
- Removed for both mobile and web app


**Screenshots:**
![Screenshot from 2024-05-10 22-39-28](https://github.com/The-Commit-Company/Raven/assets/78342682/f054ffde-ce76-4559-821f-830986e9fd4e)


**Related Issues/PRs:**
This PR addresses issue #903 [bug] alignment of avatar with the text in poll results.

**Request for Review:**
I would greatly appreciate your feedback on the implementation and any suggestions for improvement.

**Closing:**
Thank you for considering my contribution. I'm excited about the opportunity to contribute to this project and look forward to hearing your thoughts.
