### PR TITLE
131 user should be able to set their availability status

### DIFF
--- a/raven-app/src/components/feature/saved-messages/SavedMessages.tsx
+++ b/raven-app/src/components/feature/saved-messages/SavedMessages.tsx
@@ -39,7 +39,7 @@ const SavedMessages = () => {
                     <Heading size='5'>Saved Messages</Heading>
                 </Flex>
             </PageHeader>
-            <Box className="min-h-screen pt-20 pb-8">
+            <Box className="min-h-screen pt-16 pb-8">
                 <ErrorBanner error={error} />
                 {data && data.message?.length === 0 && <EmptyStateForSavedMessages />}
                 <Flex direction='column' gap='3' justify='start' px='4'>

--- a/raven-app/src/components/layout/Sidebar/SidebarFooter.tsx
+++ b/raven-app/src/components/layout/Sidebar/SidebarFooter.tsx
@@ -8,9 +8,11 @@ import { UserAvatar } from '@/components/common/UserAvatar'
 import { isSystemManager } from '@/utils/roles'
 import { BsEmojiSmile } from 'react-icons/bs'
 import { SetCustomStatusModal } from '@/components/feature/userSettings/SetCustomStatusModal'
-import { FiSettings } from 'react-icons/fi'
 import { SetUserAvailabilityMenu } from '@/components/feature/userSettings/SetUserAvailabilityMenu'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
+import { useIsDesktop } from '@/hooks/useMediaQuery'
+import { SlSettings } from 'react-icons/sl'
+import { TbUsersPlus } from 'react-icons/tb'
 
 export const SidebarFooter = ({ isSettingsPage = false }: { isSettingsPage?: boolean }) => {
 
@@ -23,6 +25,8 @@ export const SidebarFooter = ({ isSettingsPage = false }: { isSettingsPage?: boo
     const canAddUsers = isSystemManager()
 
     const { myProfile } = useCurrentRavenUser()
+
+    const isDesktop = useIsDesktop()
 
     return (
         <Flex
@@ -49,20 +53,20 @@ export const SidebarFooter = ({ isSettingsPage = false }: { isSettingsPage?: boo
                         <DropdownMenu.Content variant='soft'>
                             <SetUserAvailabilityMenu />
                             <DropdownMenu.Item color='gray' className={'flex justify-normal gap-2'} onClick={() => setUserStatusModalOpen(true)}>
-                                <BsEmojiSmile className={'text-gray-400'} /> Set custom status
+                                <BsEmojiSmile size='14' className={'text-gray-10'} /> Set custom status
                             </DropdownMenu.Item>
-                             {canAddUsers &&
+                            {canAddUsers &&
                                 <DropdownMenu.Separator className='hidden sm:block' />
                             }
-                            {canAddUsers &&
-                                <DropdownMenu.Item color='gray' onClick={() => setIsAddUserModalOpen(true)} className="cursor-pointer hidden sm:block">
-                                    Add users to Raven
+                            {canAddUsers && isDesktop &&
+                                <DropdownMenu.Item color='gray' onClick={() => setIsAddUserModalOpen(true)} className={'flex justify-normal gap-2'}>
+                                    <TbUsersPlus size='14' className={'text-gray-10'} /> Add users to Raven
                                 </DropdownMenu.Item>
                             }
-                            {!isSettingsPage && <DropdownMenu.Item color='gray' className='focus-visible:ring-0 focus-visible:outline-none rounded-radius2 cursor-pointer hidden sm:block' asChild>
+                            {!isSettingsPage && isDesktop && <DropdownMenu.Item color='gray' className='focus-visible:ring-0 focus-visible:outline-none rounded-radius2 cursor-pointer' asChild>
                                 <Link href="../settings/integrations/webhooks" className='no-underline'>
                                     <Flex gap='2' align='center'>
-                                        <FiSettings className={'text-gray-400'} /> Settings
+                                        <SlSettings size='14' className={'text-gray-10'} /> Settings
                                     </Flex>
                                 </Link>
                             </DropdownMenu.Item>}


### PR DESCRIPTION
1. Added menu for user to set their availability status, this can be reset by the user.
2. Added modal for the user to add a custom status. This will be shown in the user's hover card as well as the user's header in DM channel.

<img width="1512" alt="Screenshot 2024-05-24 at 7 56 27 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/dbf30b02-68d0-41d5-9bea-43ca0e099e2a">
<img width="1512" alt="Screenshot 2024-05-24 at 7 56 03 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/afcd8dea-f327-4ef4-8fb2-7a20066b0bbc">