### PR TITLE
feat: add doctype preview card

### DIFF
--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -1,5 +1,5 @@
 import { useDoctypePreview } from "@/hooks/useDoctypePreview"
-import { Flex, Heading, IconButton, Skeleton, Tooltip } from "@radix-ui/themes"
+import { Badge, Flex, Heading, IconButton, Skeleton, Tooltip } from "@radix-ui/themes"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { useContext } from "react"
 import { Grid, Text, Box, Card } from "@radix-ui/themes"
@@ -59,14 +59,19 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                                 </Text>
                             </Grid>
                         </Card> :
-                        <DoctypeCard data={data} copyLink={copyLink} openLink={openLink} />
+                        <DoctypeCard data={data} doctype={doctype} copyLink={copyLink} openLink={openLink} />
             }
         </Box>
     )
 }
 
 
-const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, copyLink: () => Promise<void>, openLink: () => Promise<void> }) => {
+const DoctypeCard = ({ data, doctype, copyLink, openLink }: {
+    data: Record<string, any>,
+    doctype: string,
+    copyLink: () => Promise<void>,
+    openLink: () => Promise<void>
+}) => {
 
     // utility func to remove known preview fields in order to map rest of them
     const removePreviewFields = (data: Record<string, any>) => {
@@ -122,16 +127,19 @@ const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, 
                         </Box>
                     }
                     <Flex justify='between' className='flex-1'>
-                        <Grid gap='0'>
+                        <Grid gap='1'>
                             <Heading as='h3' size='4'>{data?.preview_title}</Heading>
-                            <Text
-                                size='2'
-                                color='gray'
-                                className='cursor-copy'
-                                onClick={() => onCopyTextClick('ID')}
-                            >
-                                {data?.id}
-                            </Text>
+                            <Flex gap="1">
+                                <Badge className="accent">{doctype}</Badge>
+                                <Text
+                                    size='2'
+                                    color='gray'
+                                    className='cursor-copy'
+                                    onClick={() => onCopyTextClick('ID')}
+                                >
+                                    {data?.id}
+                                </Text>
+                            </Flex>
                         </Grid>
                         <Flex gap='2' align='center'>
                             <Tooltip content='Open in new tab'>

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -4,8 +4,7 @@ import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { useContext } from "react"
 import { Grid, Text, Box, Card } from "@radix-ui/themes"
 import { toast } from "sonner"
-import { BiCopy } from "react-icons/bi"
-import { FiExternalLink } from "react-icons/fi"
+import { BiCopy, BiLinkExternal } from "react-icons/bi"
 
 
 export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, docname: string }) => {
@@ -44,17 +43,17 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
     }
 
     return (
-        <Box className="max-w-[550px] min-w-[75px]">
+        <Box className='max-w-[550px] min-w-[75px]'>
             {
                 isLoading ?
                     <Skeleton className='w-96 h-12 rounded-md' /> :
                     error ?
                         <Card>
-                            <Grid gap="2" align="center">
-                                <Heading as="h3" size="4">Error occurred while loading Doctype</Heading>
+                            <Grid gap='2' align='center'>
+                                <Heading as='h3' size='4'>Error occurred while loading Doctype</Heading>
                                 <Text
-                                    size="2"
-                                    color="gray"
+                                    size='2'
+                                    color='gray'
                                 >
                                     {error.message}
                                 </Text>
@@ -69,6 +68,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
 
 const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, copyLink: () => Promise<void>, openLink: () => Promise<void> }) => {
 
+    // utility func to remove known preview fields in order to map rest of them
     const removePreviewFields = (data: Record<string, any>) => {
         const fieldsToRemove = ['preview_image', 'preview_title', 'id']
         return Object.keys(data).reduce((acc, key) => {
@@ -100,8 +100,8 @@ const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, 
 
     return (
         <Card>
-            <Grid gap="2">
-                <Flex gap="4" align="center">
+            <Grid gap='2'>
+                <Flex gap='4' align='center'>
                     {
                         data?.preview_image &&
                         <Box>
@@ -121,38 +121,38 @@ const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, 
                             />
                         </Box>
                     }
-                    <Flex justify="between" className="flex-1">
-                        <Grid gap="0">
-                            <Heading as="h3" size="4">{data?.preview_title}</Heading>
+                    <Flex justify='between' className='flex-1'>
+                        <Grid gap='0'>
+                            <Heading as='h3' size='4'>{data?.preview_title}</Heading>
                             <Text
-                                size="2"
-                                color="gray"
-                                className="cursor-copy"
-                                onClick={() => onCopyTextClick("ID")}
+                                size='2'
+                                color='gray'
+                                className='cursor-copy'
+                                onClick={() => onCopyTextClick('ID')}
                             >
                                 {data?.id}
                             </Text>
                         </Grid>
-                        <Flex gap="2" align="center">
-                            <Tooltip content="Open in new tab">
+                        <Flex gap='2' align='center'>
+                            <Tooltip content='Open in new tab'>
                                 <IconButton
-                                    size={'1'}
-                                    title="Open in new tab"
+                                    size='1'
+                                    title='Open in new tab'
                                     color='gray'
                                     onClick={openLink}
-                                    variant="soft"
+                                    variant='soft'
                                 >
-                                    <FiExternalLink />
+                                    <BiLinkExternal />
                                 </IconButton>
                             </Tooltip>
 
-                            <Tooltip content="Copy link">
+                            <Tooltip content='Copy link'>
                                 <IconButton
                                     size='1'
-                                    title="Copy link"
+                                    title='Copy link'
                                     color='gray'
                                     onClick={onCopyLinkClick}
-                                    variant="soft"
+                                    variant='soft'
                                 >
                                     <BiCopy />
                                 </IconButton>
@@ -161,23 +161,23 @@ const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, 
                     </Flex>
                 </Flex>
 
-                <Grid gap="2" >
+                <Grid gap='2' >
                     {
                         data && Object.keys(removePreviewFields(data))?.map((item, index) => (
-                            <Flex key={item + index} gap="4" align="center">
+                            <Flex key={item + index} gap='4' align='center'>
                                 <Flex>
                                     <Text
-                                        size="2"
-                                        weight="bold"
-                                        color="gray"
+                                        size='2'
+                                        weight='bold'
+                                        color='gray'
                                     >
                                         {item}
                                     </Text>
                                 </Flex>
-                                <Flex gap="2" align="center">
+                                <Flex gap='2' align='center'>
                                     <Text
-                                        size="2"
-                                        className="cursor-copy"
+                                        size='2'
+                                        className='cursor-copy'
                                         onClick={() => onCopyTextClick(item)}
                                     >
                                         {data[item]}

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -40,7 +40,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
         }, {} as Record<string, any>)
     }
 
-    const onCopyClick = () => {
+    const onCopyLinkClick = () => {
         toast.promise(copyLink, {
             loading: 'Copying link...',
             success: 'Link copied!',
@@ -48,8 +48,17 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
         })
     }
 
-    const copyToClipboard = (text: string) => navigator.clipboard.writeText(text)
+    const onCopyTextClick = (item: string) => {
+        toast.promise(() => copyToClipboard(data[item]), {
+            loading: `Copying ${item}...`,
+            success: `${item} copied!`,
+            error: `Failed to copy ${item}`,
+            duration: 1000
+        })
+    }
 
+    const copyToClipboard = (text: string) => navigator.clipboard.writeText(text) 
+    
     const copyLink = async () => {
 
         const route = await getRoute(doctype, docname)
@@ -69,10 +78,10 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                 <Grid gap="2">
                     <Flex gap="4" align="center">
                         {
-                            !data?.preview_image ?
+                            data?.preview_image ?
                                 <Box>
                                     <img
-                                        src="https://images.unsplash.com/photo-1617050318658-a9a3175e34cb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=600&q=80"
+                                        src={data.preview_image}
                                         alt="Bold typography"
                                         style={{
                                             objectFit: 'cover',
@@ -90,13 +99,14 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                         }
                         <Flex justify="between" className="flex-1">
                             <Grid gap="0">
-                                <Heading as="h3" size="4">{data.preview_title}</Heading>
+                                <Heading as="h3" size="4">{data?.preview_title}</Heading>
                                 <Text
                                     size="2"
                                     color="gray"
                                     className="cursor-copy"
-                                    onClick={() => copyToClipboard(data.id)}>
-                                    {data.id}
+                                    onClick={()=>onCopyTextClick("ID")}
+                                >
+                                    {data?.id}
                                 </Text>
                             </Grid>
                             <Flex gap="2" align="center">
@@ -117,7 +127,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                                         size='1'
                                         title="Copy link"
                                         color='gray'
-                                        onClick={onCopyClick}
+                                        onClick={onCopyLinkClick}
                                         variant="soft"
                                     >
                                         <BiCopy />
@@ -129,7 +139,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
 
                     <Grid gap="2" >
                         {
-                            Object.keys(removePreviewFields(data))?.map((item, index) => (
+                            data && Object.keys(removePreviewFields(data))?.map((item, index) => (
                                 <Flex key={item + index} gap="4" align="center">
                                     <Flex>
                                         <Text
@@ -144,7 +154,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                                         <Text
                                             size="2"
                                             className="cursor-copy"
-                                            onClick={() => copyToClipboard(data[item])}
+                                            onClick={()=>onCopyTextClick(item)}
                                         >
                                             {data[item]}
                                         </Text>

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -1,14 +1,17 @@
-import { Flex, IconButton, Link } from "@radix-ui/themes"
+import { useDoctypePreview } from "@/hooks/useDoctypePreview"
+import { Flex, Heading, IconButton, Tooltip } from "@radix-ui/themes"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { useContext } from "react"
-import { BiLink, BiRightArrowAlt } from "react-icons/bi"
-import { FiExternalLink } from "react-icons/fi"
+import { Grid, Text, Box, Card } from "@radix-ui/themes"
 import { toast } from "sonner"
+import { BiCopy } from "react-icons/bi"
+import { FiExternalLink } from "react-icons/fi"
 
 
 export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, docname: string }) => {
 
     const { call } = useContext(FrappeContext) as FrappeConfig
+    const { data, error, isLoading } = useDoctypePreview(doctype, docname)
 
     const getRoute = async (doctype: string, docname: string): Promise<string> => {
 
@@ -27,6 +30,16 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
 
     }
 
+    const removePreviewFields = (data: Record<string, any>) => {
+        const fieldsToRemove = ['preview_image', 'preview_title', 'id']
+        return Object.keys(data).reduce((acc, key) => {
+            if (!fieldsToRemove.includes(key)) {
+                acc[key as keyof typeof data] = data[key]
+            }
+            return acc
+        }, {} as Record<string, any>)
+    }
+
     const onCopyClick = () => {
         toast.promise(copyLink, {
             loading: 'Copying link...',
@@ -34,6 +47,8 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
             error: 'Failed to copy link'
         })
     }
+
+    const copyToClipboard = (text: string) => navigator.clipboard.writeText(text)
 
     const copyLink = async () => {
 
@@ -49,38 +64,97 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
     }
 
     return (
-        <Flex
-            align='center'
-            gap='4'
-            mt={'1'}
-            p='2'
-            className="border-2 bg-gray-2 dark:bg-gray-4 rounded-md border-gray-4  dark:border-gray-6 shadow-sm">
-            <Flex align='center' gap='2'>
-                <BiRightArrowAlt />
-                <Link size='2' underline="always" onClick={openLink}>{doctype}: {docname}</Link>
-            </Flex>
+        <Box className="max-w-[550px] min-w-[75px]">
+            <Card>
+                <Grid gap="2">
+                    <Flex gap="4" align="center">
+                        {
+                            !data?.preview_image ?
+                                <Box>
+                                    <img
+                                        src="https://images.unsplash.com/photo-1617050318658-a9a3175e34cb?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=600&q=80"
+                                        alt="Bold typography"
+                                        style={{
+                                            objectFit: 'cover',
+                                            width: '100%',
+                                            minWidth: '50px',
+                                            minHeight: '50px',
+                                            maxWidth: '100px',
+                                            maxHeight: '100px',
+                                            backgroundColor: 'var(--gray-5)',
+                                            borderRadius: 'var(--radius-4)'
+                                        }}
+                                    />
+                                </Box>
+                                : null
+                        }
+                        <Flex justify="between" className="flex-1">
+                            <Grid gap="0">
+                                <Heading as="h3" size="4">{data.preview_title}</Heading>
+                                <Text
+                                    size="2"
+                                    color="gray"
+                                    className="cursor-copy"
+                                    onClick={() => copyToClipboard(data.id)}>
+                                    {data.id}
+                                </Text>
+                            </Grid>
+                            <Flex gap="2" align="center">
+                                <Tooltip content="Open in new tab">
+                                    <IconButton
+                                        size={'1'}
+                                        title="Open in new tab"
+                                        color='gray'
+                                        onClick={openLink}
+                                        variant="soft"
+                                    >
+                                        <FiExternalLink />
+                                    </IconButton>
+                                </Tooltip>
 
-            <Flex align='center' gap='2'>
-                <IconButton
-                    size={'1'}
-                    title="Open in new tab"
-                    color='gray'
-                    onClick={openLink}
-                    variant="soft"
-                >
-                    <FiExternalLink />
-                </IconButton>
+                                <Tooltip content="Copy link">
+                                    <IconButton
+                                        size='1'
+                                        title="Copy link"
+                                        color='gray'
+                                        onClick={onCopyClick}
+                                        variant="soft"
+                                    >
+                                        <BiCopy />
+                                    </IconButton>
+                                </Tooltip>
+                            </Flex>
+                        </Flex>
+                    </Flex>
 
-                <IconButton
-                    size='1'
-                    title="Copy link"
-                    color='gray'
-                    onClick={onCopyClick}
-                    variant="soft"
-                >
-                    <BiLink />
-                </IconButton>
-            </Flex>
-        </Flex>
+                    <Grid gap="2" >
+                        {
+                            Object.keys(removePreviewFields(data))?.map((item, index) => (
+                                <Flex key={item + index} gap="4" align="center">
+                                    <Flex>
+                                        <Text
+                                            size="2"
+                                            weight="bold"
+                                            color="gray"
+                                        >
+                                            {item}
+                                        </Text>
+                                    </Flex>
+                                    <Flex gap="2" align="center">
+                                        <Text
+                                            size="2"
+                                            className="cursor-copy"
+                                            onClick={() => copyToClipboard(data[item])}
+                                        >
+                                            {data[item]}
+                                        </Text>
+                                    </Flex>
+                                </Flex>
+                            ))
+                        }
+                    </Grid>
+                </Grid>
+            </Card>
+        </Box>
     )
 }

--- a/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/raven-app/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -1,5 +1,5 @@
 import { useDoctypePreview } from "@/hooks/useDoctypePreview"
-import { Flex, Heading, IconButton, Tooltip } from "@radix-ui/themes"
+import { Flex, Heading, IconButton, Skeleton, Tooltip } from "@radix-ui/themes"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { useContext } from "react"
 import { Grid, Text, Box, Card } from "@radix-ui/themes"
@@ -30,6 +30,45 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
 
     }
 
+    const copyLink = async () => {
+
+        const route = await getRoute(doctype, docname)
+
+        return navigator.clipboard.writeText(route)
+    }
+
+    const openLink = async () => {
+        const route = await getRoute(doctype, docname)
+
+        window.open(route, '_blank')
+    }
+
+    return (
+        <Box className="max-w-[550px] min-w-[75px]">
+            {
+                isLoading ?
+                    <Skeleton className='w-96 h-12 rounded-md' /> :
+                    error ?
+                        <Card>
+                            <Grid gap="2" align="center">
+                                <Heading as="h3" size="4">Error occurred while loading Doctype</Heading>
+                                <Text
+                                    size="2"
+                                    color="gray"
+                                >
+                                    {error.message}
+                                </Text>
+                            </Grid>
+                        </Card> :
+                        <DoctypeCard data={data} copyLink={copyLink} openLink={openLink} />
+            }
+        </Box>
+    )
+}
+
+
+const DoctypeCard = ({ data, copyLink, openLink }: { data: Record<string, any>, copyLink: () => Promise<void>, openLink: () => Promise<void> }) => {
+
     const removePreviewFields = (data: Record<string, any>) => {
         const fieldsToRemove = ['preview_image', 'preview_title', 'id']
         return Object.keys(data).reduce((acc, key) => {
@@ -57,114 +96,98 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
         })
     }
 
-    const copyToClipboard = (text: string) => navigator.clipboard.writeText(text) 
-    
-    const copyLink = async () => {
-
-        const route = await getRoute(doctype, docname)
-
-        return navigator.clipboard.writeText(route)
-    }
-
-    const openLink = async () => {
-        const route = await getRoute(doctype, docname)
-
-        window.open(route, '_blank')
-    }
+    const copyToClipboard = (text: string) => navigator.clipboard.writeText(text)
 
     return (
-        <Box className="max-w-[550px] min-w-[75px]">
-            <Card>
-                <Grid gap="2">
-                    <Flex gap="4" align="center">
-                        {
-                            data?.preview_image ?
-                                <Box>
-                                    <img
-                                        src={data.preview_image}
-                                        alt="Bold typography"
-                                        style={{
-                                            objectFit: 'cover',
-                                            width: '100%',
-                                            minWidth: '50px',
-                                            minHeight: '50px',
-                                            maxWidth: '100px',
-                                            maxHeight: '100px',
-                                            backgroundColor: 'var(--gray-5)',
-                                            borderRadius: 'var(--radius-4)'
-                                        }}
-                                    />
-                                </Box>
-                                : null
-                        }
-                        <Flex justify="between" className="flex-1">
-                            <Grid gap="0">
-                                <Heading as="h3" size="4">{data?.preview_title}</Heading>
-                                <Text
-                                    size="2"
-                                    color="gray"
-                                    className="cursor-copy"
-                                    onClick={()=>onCopyTextClick("ID")}
+        <Card>
+            <Grid gap="2">
+                <Flex gap="4" align="center">
+                    {
+                        data?.preview_image &&
+                        <Box>
+                            <img
+                                src={data.preview_image}
+                                alt={data?.preview_title}
+                                style={{
+                                    objectFit: 'cover',
+                                    width: '100%',
+                                    minWidth: '50px',
+                                    minHeight: '50px',
+                                    maxWidth: '100px',
+                                    maxHeight: '100px',
+                                    backgroundColor: 'var(--gray-5)',
+                                    borderRadius: 'var(--radius-4)'
+                                }}
+                            />
+                        </Box>
+                    }
+                    <Flex justify="between" className="flex-1">
+                        <Grid gap="0">
+                            <Heading as="h3" size="4">{data?.preview_title}</Heading>
+                            <Text
+                                size="2"
+                                color="gray"
+                                className="cursor-copy"
+                                onClick={() => onCopyTextClick("ID")}
+                            >
+                                {data?.id}
+                            </Text>
+                        </Grid>
+                        <Flex gap="2" align="center">
+                            <Tooltip content="Open in new tab">
+                                <IconButton
+                                    size={'1'}
+                                    title="Open in new tab"
+                                    color='gray'
+                                    onClick={openLink}
+                                    variant="soft"
                                 >
-                                    {data?.id}
-                                </Text>
-                            </Grid>
-                            <Flex gap="2" align="center">
-                                <Tooltip content="Open in new tab">
-                                    <IconButton
-                                        size={'1'}
-                                        title="Open in new tab"
-                                        color='gray'
-                                        onClick={openLink}
-                                        variant="soft"
-                                    >
-                                        <FiExternalLink />
-                                    </IconButton>
-                                </Tooltip>
+                                    <FiExternalLink />
+                                </IconButton>
+                            </Tooltip>
 
-                                <Tooltip content="Copy link">
-                                    <IconButton
-                                        size='1'
-                                        title="Copy link"
-                                        color='gray'
-                                        onClick={onCopyLinkClick}
-                                        variant="soft"
-                                    >
-                                        <BiCopy />
-                                    </IconButton>
-                                </Tooltip>
-                            </Flex>
+                            <Tooltip content="Copy link">
+                                <IconButton
+                                    size='1'
+                                    title="Copy link"
+                                    color='gray'
+                                    onClick={onCopyLinkClick}
+                                    variant="soft"
+                                >
+                                    <BiCopy />
+                                </IconButton>
+                            </Tooltip>
                         </Flex>
                     </Flex>
+                </Flex>
 
-                    <Grid gap="2" >
-                        {
-                            data && Object.keys(removePreviewFields(data))?.map((item, index) => (
-                                <Flex key={item + index} gap="4" align="center">
-                                    <Flex>
-                                        <Text
-                                            size="2"
-                                            weight="bold"
-                                            color="gray"
-                                        >
-                                            {item}
-                                        </Text>
-                                    </Flex>
-                                    <Flex gap="2" align="center">
-                                        <Text
-                                            size="2"
-                                            className="cursor-copy"
-                                            onClick={()=>onCopyTextClick(item)}
-                                        >
-                                            {data[item]}
-                                        </Text>
-                                    </Flex>
+                <Grid gap="2" >
+                    {
+                        data && Object.keys(removePreviewFields(data))?.map((item, index) => (
+                            <Flex key={item + index} gap="4" align="center">
+                                <Flex>
+                                    <Text
+                                        size="2"
+                                        weight="bold"
+                                        color="gray"
+                                    >
+                                        {item}
+                                    </Text>
                                 </Flex>
-                            ))
-                        }
-                    </Grid>
+                                <Flex gap="2" align="center">
+                                    <Text
+                                        size="2"
+                                        className="cursor-copy"
+                                        onClick={() => onCopyTextClick(item)}
+                                    >
+                                        {data[item]}
+                                    </Text>
+                                </Flex>
+                            </Flex>
+                        ))
+                    }
                 </Grid>
-            </Card>
-        </Box>
+            </Grid>
+        </Card>
     )
 }

--- a/raven-app/src/hooks/useDoctypePreview.ts
+++ b/raven-app/src/hooks/useDoctypePreview.ts
@@ -11,7 +11,7 @@ export const useDoctypePreview = (doctype: string, docname: string) => {
     })
 
     return {
-        data: data.message,
+        data: data?.message,
         error,
         isLoading
     }

--- a/raven-app/src/hooks/useDoctypePreview.ts
+++ b/raven-app/src/hooks/useDoctypePreview.ts
@@ -2,7 +2,7 @@ import { useFrappeGetCall } from "frappe-react-sdk"
 
 /**
  * Simple hook to show Doctype preview data
- * @returns Description, Item Group, name(id), preview_image, preview_title
+ * @returns name(id), preview_image, preview_title and rest fields depending on Doctype
  */
 export const useDoctypePreview = (doctype: string, docname: string) => {
     const {data, error, isLoading} = useFrappeGetCall('raven.api.document_link.get_preview_data', {

--- a/raven-app/src/hooks/useDoctypePreview.ts
+++ b/raven-app/src/hooks/useDoctypePreview.ts
@@ -1,0 +1,18 @@
+import { useFrappeGetCall } from "frappe-react-sdk"
+
+/**
+ * Simple hook to show Doctype preview data
+ * @returns Description, Item Group, name(id), preview_image, preview_title
+ */
+export const useDoctypePreview = (doctype: string, docname: string) => {
+    const {data, error, isLoading} = useFrappeGetCall('raven.api.document_link.get_preview_data', {
+        doctype,
+        docname
+    })
+
+    return {
+        data: data.message,
+        error,
+        isLoading
+    }
+}

--- a/raven/api/document_link.py
+++ b/raven/api/document_link.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.desk.utils import slug
+from frappe.model.meta import no_value_fields, table_fields
 
 
 @frappe.whitelist(methods=["GET"])
@@ -15,3 +16,50 @@ def get(doctype, docname):
 				return link
 
 	return f"/app/{slug(doctype)}/{docname}"
+
+@frappe.whitelist(methods=["GET"])
+def get_preview_data(doctype, docname):
+	preview_fields = []
+	meta = frappe.get_meta(doctype)
+
+	preview_fields = [
+		field.fieldname
+		for field in meta.fields
+		if field.in_preview and field.fieldtype not in no_value_fields and field.fieldtype not in table_fields
+	]
+
+	# no preview fields defined, build list from mandatory fields
+	if not preview_fields:
+		preview_fields = [
+			field.fieldname for field in meta.fields if field.reqd and field.fieldtype not in table_fields
+		]
+
+	title_field = meta.get_title_field()
+	image_field = meta.image_field
+
+	preview_fields.append(title_field)
+	preview_fields.append(image_field)
+	preview_fields.append("name")
+
+	preview_data = frappe.get_list(doctype, filters={"name": docname}, fields=preview_fields, limit=1)
+
+	if not preview_data:
+		return
+
+	preview_data = preview_data[0]
+
+	formatted_preview_data = {
+		"preview_image": preview_data.get(image_field),
+		"preview_title": preview_data.get(title_field),
+		"id": preview_data.get("name"),
+	}
+
+	for key, val in preview_data.items():
+		if val and meta.has_field(key) and key not in [image_field, title_field, "name"]:
+			formatted_preview_data[meta.get_field(key).label] = frappe.format(
+				val,
+				meta.get_field(key).fieldtype,
+				translated=True,
+			)
+
+	return formatted_preview_data


### PR DESCRIPTION
###  Feature:
- Preview Doctype links inside chat.
- Create hook and api for doctype preview.
- Add copy to clipboard, copy link and open in new tab functionality.
- Handle Error and Loading states.


### Screenshot:

<img width="1226" alt="image" src="https://github.com/The-Commit-Company/Raven/assets/59260326/1b021f51-79cf-4d70-a126-7c57f2df5993">
