### PR TITLE
fix: make saved messages header mobile responsive

### DIFF
--- a/frontend/src/components/layout/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/layout/EmptyState/EmptyState.tsx
@@ -41,7 +41,7 @@ const EmptyStateForChannel = ({ channelData }: EmptyStateForChannelProps) => {
     const users = useGetUserRecords()
 
     return (
-        <Flex direction='column' className={'py-4 px-2'} gap='2'>
+        <Flex direction='column' className={'p-2'} gap='2'>
             <Flex direction='column' gap='2'>
                 <Flex align={'center'} gap='1'>
                     <ChannelIcon type={channelData?.type} />
@@ -80,7 +80,7 @@ const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
     const isActive = useIsUserActive(peer)
 
     return (
-        <Box className={'py-4 px-2'}>
+        <Box className={'p-2'}>
             {channelData?.is_direct_message == 1 &&
                 <Flex direction='column' gap='3'>
                     <Flex gap='3' align='center'>
@@ -110,16 +110,14 @@ const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
 
 export const EmptyStateForSavedMessages = () => {
     return (
-        <Box className={'py-1 px-4'}>
+        <Box className={'py-2 px-6'}>
             <Flex direction='column' gap='2'>
                 <Text size='3'><strong>Your saved messages will appear here</strong></Text>
                 <Flex direction='column' gap='1'>
-                    <Text size='2'>Saved messages are a convenient way to keep track of important information or messages you want to refer back to later.</Text>
-                    <Flex align='center' gap='1'>
-                        <Text size='2'>You can save messages by simply clicking on the bookmark icon</Text>
-                        <BiBookmark />
-                        <Text size='2'>in message actions.</Text>
-                    </Flex>
+                    <Text size='2' as='span'>Saved messages are a convenient way to keep track of important information or messages you want to refer back to later.</Text>
+                    <Text size='2' as='span'>
+                        You can save messages by simply clicking on the bookmark icon <BiBookmark className={'-mb-0.5'} /> in message actions.
+                    </Text>
                 </Flex>
             </Flex>
         </Box>


### PR DESCRIPTION
<img width="223" alt="Screenshot 2024-06-14 at 4 41 12 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/fc55526c-6fce-45d1-bfa6-bc3c8a74dac5">
<img width="223" alt="Screenshot 2024-06-14 at 4 04 58 PM" src="https://github.com/The-Commit-Company/Raven/assets/29656465/7123a543-f0b1-4363-8fb9-5aa07d57c1fc">
