### PR TITLE
fix: migrate older Raven Users with type set to "User"

### DIFF
--- a/raven/patches.txt
+++ b/raven/patches.txt
@@ -6,3 +6,4 @@ raven.patches.v1_3.create_raven_message_indexes #23
 raven.patches.v1_3.update_all_messages_to_include_message_content #2
 raven.patches.v1_3.update_all_messages_to_include_replied_message_content #2
 raven.patches.v1_6.create_raven_channel_member_index
+raven.patches.v1_6.migrate_older_raven_users

--- a/raven/patches/v1_6/migrate_older_raven_users.py
+++ b/raven/patches/v1_6/migrate_older_raven_users.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	"""
+	Migrate Raven User to have the "type" field set for older Raven Users
+	"""
+
+	users = frappe.get_all("Raven User", filters={"type": ["in", ["", None]]}, pluck="name", limit=5)
+
+	for user in users:
+		frappe.db.set_value("Raven User", user, "type", "User")


### PR DESCRIPTION
Raven Users created earlier did not have any "type" set. This patch adds a "type" of "User" to those.