### PR TITLE
fix: use vite from environment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,9 @@
   "version": "1.6.4",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build --base=/assets/raven/raven/ && yarn copy-html-entry",
-    "preview": "vite preview",
+    "dev": "yarn vite",
+    "build": "yarn vite build --base=/assets/raven/raven/ && yarn copy-html-entry",
+    "preview": "yarn vite preview",
     "copy-html-entry": "cp ../raven/public/raven/index.html ../raven/www/raven.html"
   },
   "dependencies": {


### PR DESCRIPTION
Previously, I get the same error in two scenarios:

- CLI
- Build

Here's the equivalent CLI error:
```
❯ vite
zsh: command not found: vite
```

By using `yarn vite`, we ensue that we use the yarn installed version as declared by the `package.json`.
