### PR TITLE
fix: show "deleted user" if Raven User not found

### DIFF
--- a/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
+++ b/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
@@ -17,12 +17,12 @@ const DMChannelItem = ({ channelID, peer_user_id }: { channelID: string, peer_us
     }
 
     return <Command.Item
-        keywords={[user?.full_name ?? peer_user_id]}
-        value={peer_user_id}
+        keywords={[user?.full_name ?? peer_user_id ?? "Deleted User"]}
+        value={peer_user_id ?? channelID}
         onSelect={onSelect}>
         <UserAvatar src={user?.user_image} alt={user?.full_name ?? peer_user_id}
             isBot={user?.type === 'Bot'} />
-        {user?.full_name}
+        {user?.full_name ?? peer_user_id ?? "Deleted User"}
     </Command.Item>
 }
 

--- a/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
+++ b/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
@@ -4,9 +4,13 @@ import { Command } from "cmdk"
 import { commandMenuOpenAtom } from "./CommandMenu"
 import { useSetAtom } from "jotai"
 import { useNavigate } from "react-router-dom"
+import { useContext } from "react"
+import { UserContext } from "@/utils/auth/UserProvider"
+import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
 
-const DMChannelItem = ({ channelID, peer_user_id }: { channelID: string, peer_user_id: string }) => {
+const DMChannelItem = ({ channelID, peer_user_id, channelName }: { channelID: string, channelName: string, peer_user_id: string }) => {
 
+    const { currentUser } = useContext(UserContext)
     const user = useGetUser(peer_user_id)
     const navigate = useNavigate()
     const setOpen = useSetAtom(commandMenuOpenAtom)
@@ -17,12 +21,12 @@ const DMChannelItem = ({ channelID, peer_user_id }: { channelID: string, peer_us
     }
 
     return <Command.Item
-        keywords={[user?.full_name ?? peer_user_id ?? "Deleted User"]}
+        keywords={[user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)}`]}
         value={peer_user_id ?? channelID}
         onSelect={onSelect}>
         <UserAvatar src={user?.user_image} alt={user?.full_name ?? peer_user_id}
             isBot={user?.type === 'Bot'} />
-        {user?.full_name ?? peer_user_id ?? "Deleted User"}
+        {user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)} (Deleted)`}
     </Command.Item>
 }
 

--- a/frontend/src/components/feature/CommandMenu/UserList.tsx
+++ b/frontend/src/components/feature/CommandMenu/UserList.tsx
@@ -24,7 +24,7 @@ const UserList = () => {
 
     return (
         <Command.Group heading="Members">
-            {dm_channels.map((channel) => <DMChannelItem key={channel.name} channelID={channel.name} peer_user_id={channel.peer_user_id} />)}
+            {dm_channels.map((channel) => <DMChannelItem key={channel.name} channelID={channel.name} channelName={channel.channel_name} peer_user_id={channel.peer_user_id} />)}
             {usersWithoutChannels.map((user) => <UserWithoutDMItem key={user.name} userID={user.name} />)}
         </Command.Group>
     )

--- a/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
+++ b/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
@@ -3,19 +3,23 @@ import { useIsUserActive } from "@/hooks/useIsUserActive"
 import { DMChannelListItem } from "@/utils/channel/ChannelListProvider"
 import { Badge, Flex, Heading } from "@radix-ui/themes"
 import { UserAvatar } from "@/components/common/UserAvatar"
-import { useMemo } from "react"
+import { useContext, useMemo } from "react"
 import useFetchChannelMembers from "@/hooks/fetchers/useFetchChannelMembers"
 import ChannelHeaderMenu from "./ChannelHeaderMenu"
 import { BiChevronLeft } from "react-icons/bi"
 import { Link } from "react-router-dom"
 import { useGetUser } from "@/hooks/useGetUser"
 import useIsUserOnLeave from "@/hooks/fetchers/useIsUserOnLeave"
+import { UserContext } from "@/utils/auth/UserProvider"
+import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
 
 interface DMChannelHeaderProps {
     channelData: DMChannelListItem,
 }
 
 export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
+
+    const { currentUser } = useContext(UserContext)
 
     const { channelMembers } = useFetchChannelMembers(channelData.name)
 
@@ -60,7 +64,7 @@ export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
                     size='2' />
                 <Heading size='5'>
                     <div className="flex items-center gap-2">
-                        {fullName}
+                        {fullName ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)}
                         {user?.custom_status && <Badge color='gray' className='font-semibold px-1.5 py-0.5'>{user.custom_status}</Badge>}
                         {isUserOnLeave && <Badge color="yellow" variant="surface">On Leave</Badge>}
                         {isBot && <Badge color='gray' className='font-semibold px-1.5 py-0.5'>Bot</Badge>}

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -101,14 +101,14 @@ export const DirectMessageItemElement = ({ channel, unreadCount }: { channel: DM
                     md: '1'
                 }}
                 availabilityStatus={userData?.availability_status}
-                 />
+            />
         </SidebarIcon>
         <Flex justify='between' width='100%'>
             <Text size={{
                 initial: '3',
                 md: '2'
             }} className="text-ellipsis line-clamp-1" weight={showUnread ? 'bold' : 'medium'}>
-                {channel.peer_user_id !== currentUser ? userData?.full_name ?? channel.peer_user_id : `${userData?.full_name} (You)`}
+                {channel.peer_user_id !== currentUser ? userData?.full_name ?? channel.peer_user_id ?? "Deleted User" : `${userData?.full_name} (You)`}
             </Text>
             {showUnread ? <SidebarBadge>{unreadCount}</SidebarBadge> : null}
         </Flex>
@@ -170,7 +170,7 @@ const ExtraUsersItem = ({ user, createDMChannel }: { user: UserFields, createDMC
                     initial: '2',
                     md: '1'
                 }}
-              availabilityStatus={user.availability_status}/>
+                availabilityStatus={user.availability_status} />
         </SidebarIcon>
         <Flex justify='between' width='100%'>
             <Text size={{

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -14,6 +14,7 @@ import { getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
 import { useStickyState } from "@/hooks/useStickyState"
 import clsx from "clsx"
 import { UserFields, UserListContext } from "@/utils/users/UserListProvider"
+import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
 
 export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -108,7 +109,7 @@ export const DirectMessageItemElement = ({ channel, unreadCount }: { channel: DM
                 initial: '3',
                 md: '2'
             }} className="text-ellipsis line-clamp-1" weight={showUnread ? 'bold' : 'medium'}>
-                {channel.peer_user_id !== currentUser ? userData?.full_name ?? channel.peer_user_id ?? "Deleted User" : `${userData?.full_name} (You)`}
+                {channel.peer_user_id !== currentUser ? userData?.full_name ?? channel.peer_user_id ?? replaceCurrentUserFromDMChannelName(channel.channel_name, currentUser) : `${userData?.full_name} (You)`}
             </Text>
             {showUnread ? <SidebarBadge>{unreadCount}</SidebarBadge> : null}
         </Flex>

--- a/frontend/src/components/layout/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/layout/EmptyState/EmptyState.tsx
@@ -13,6 +13,7 @@ import { DateMonthYear } from "@/utils/dateConversions"
 import { useGetUser } from "@/hooks/useGetUser"
 import useFetchChannelMembers from "@/hooks/fetchers/useFetchChannelMembers"
 import { useIsUserActive } from "@/hooks/useIsUserActive"
+import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
 
 export const EmptyStateForSearch = () => {
     return (
@@ -64,6 +65,8 @@ interface EmptyStateForDMProps {
 
 const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
 
+    const { currentUser } = useContext(UserContext)
+
     const peer = channelData.peer_user_id
 
     const peerData = useGetUser(peer)
@@ -86,7 +89,7 @@ const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
                     <Flex gap='3' align='center'>
                         <UserAvatar alt={fullName} src={userImage} size='3' skeletonSize='7' isBot={isBot} availabilityStatus={peerData?.availability_status} isActive={isActive} />
                         <Flex direction='column' gap='0'>
-                            <Heading size='4'>{fullName}</Heading>
+                            <Heading size='4'>{fullName ?? peer ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)}</Heading>
                             <div>
                                 {isBot ? <Badge color='gray' className="py-0 px-1">Bot</Badge> : <Text size='1' color='gray'>{peer}</Text>}
                             </div>
@@ -99,7 +102,11 @@ const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
                         </Flex>
                         :
                         <Flex gap='2' align='center'>
-                            <Text size='2'>This is a Direct Message channel between you and <strong>{fullName}</strong>.</Text>
+                            {peer || fullName ?
+                                <Text size='2'>This is a Direct Message channel between you and <strong>{fullName ?? peer}</strong>.</Text>
+                                :
+                                <Text size='2'>We could not find the user for this DM channel ({replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)}).</Text>
+                            }
                         </Flex>
                     }
                 </Flex>

--- a/frontend/src/utils/operations.ts
+++ b/frontend/src/utils/operations.ts
@@ -119,3 +119,13 @@ export const formatBytes = (bytes: number, decimals = 2) => {
 
     return parseFloat((bytes / Math.pow(k, i)).toFixed(decimals)) + ' ' + sizes[i]
 }
+
+/**
+ * Function to remove the current user from the DM Channel Name - used when the peer user is not found
+ * @param channelName 
+ * @param currentUser 
+ * @returns 
+ */
+export const replaceCurrentUserFromDMChannelName = (channelName: string, currentUser: string) => {
+    return channelName.replace(currentUser, '').replace(' _ ', '')
+}


### PR DESCRIPTION
This is somewhat of a fix for #979 - at least the app does not crash.

Not sure if we should delete all DMs of Raven Users who are deleted or not. 

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/235b5b25-e5f3-4afe-93fd-df02ad6bc711">
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/ee483371-4a10-4ae3-8eb3-56ad0c22711a">
