### PR TITLE
fix: do not show disabled users in the sidebar

### DIFF
--- a/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
+++ b/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
@@ -21,17 +21,20 @@ const DMChannelItem = ({ channelID, peer_user_id, channelName }: { channelID: st
         setOpen(false)
     }
 
+    const userName = user?.full_name ?? peer_user_id ?? replaceCurrentUserFromDMChannelName(channelName, currentUser)
+
     return <Command.Item
-        keywords={[user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)}`]}
+        keywords={[userName]}
         value={peer_user_id ?? channelID}
         onSelect={onSelect}>
         <Flex gap='2' align='center' justify={'between'} width='100%'>
             <Flex gap='2' align='center'>
-                <UserAvatar src={user?.user_image} alt={user?.full_name ?? peer_user_id}
+                <UserAvatar src={user?.user_image} alt={userName}
                     isBot={user?.type === 'Bot'} />
-                {user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)} (Deleted)`}
+                {userName}
             </Flex>
-            {!user?.enabled && <Badge color='gray' variant="soft">Disabled</Badge>}
+            {user && !user?.enabled && <Badge color='gray' variant="soft">Disabled</Badge>}
+            {!user && <Badge color='gray' variant="soft">Deleted</Badge>}
         </Flex>
     </Command.Item>
 }

--- a/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
+++ b/frontend/src/components/feature/CommandMenu/DMChannelItem.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from "react-router-dom"
 import { useContext } from "react"
 import { UserContext } from "@/utils/auth/UserProvider"
 import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
+import { Badge, Flex } from "@radix-ui/themes"
 
 const DMChannelItem = ({ channelID, peer_user_id, channelName }: { channelID: string, channelName: string, peer_user_id: string }) => {
 
@@ -24,9 +25,14 @@ const DMChannelItem = ({ channelID, peer_user_id, channelName }: { channelID: st
         keywords={[user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)}`]}
         value={peer_user_id ?? channelID}
         onSelect={onSelect}>
-        <UserAvatar src={user?.user_image} alt={user?.full_name ?? peer_user_id}
-            isBot={user?.type === 'Bot'} />
-        {user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)} (Deleted)`}
+        <Flex gap='2' align='center' justify={'between'} width='100%'>
+            <Flex gap='2' align='center'>
+                <UserAvatar src={user?.user_image} alt={user?.full_name ?? peer_user_id}
+                    isBot={user?.type === 'Bot'} />
+                {user?.full_name ?? peer_user_id ?? `${replaceCurrentUserFromDMChannelName(channelName, currentUser)} (Deleted)`}
+            </Flex>
+            {!user?.enabled && <Badge color='gray' variant="soft">Disabled</Badge>}
+        </Flex>
     </Command.Item>
 }
 

--- a/frontend/src/components/feature/CommandMenu/UserList.tsx
+++ b/frontend/src/components/feature/CommandMenu/UserList.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom'
 import { useSetAtom } from 'jotai'
 import { commandMenuOpenAtom } from './CommandMenu'
 import { useFrappePostCall } from 'frappe-react-sdk'
-import { Flex } from '@radix-ui/themes'
+import { Badge, Flex } from '@radix-ui/themes'
 import { Loader } from '@/components/common/Loader'
 import { toast } from 'sonner'
 import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
@@ -63,6 +63,7 @@ const UserWithoutDMItem = ({ userID }: { userID: string }) => {
                 {user?.full_name}
             </Flex>
             {loading ? <Loader /> : null}
+            {!user?.enabled ? <Badge color='gray' variant='soft'>Disabled</Badge> : null}
         </Flex>
     </Command.Item>
 }

--- a/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
+++ b/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
@@ -47,6 +47,8 @@ export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
 
     const isUserOnLeave = useIsUserOnLeave(peer)
 
+    const userName = fullName ?? peer ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)
+
     return (
         <PageHeader>
             <Flex gap='3' align='center'>
@@ -55,7 +57,7 @@ export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
                 </Link>
                 <UserAvatar
                     key={peer}
-                    alt={fullName}
+                    alt={userName}
                     src={userImage}
                     isActive={isActive}
                     availabilityStatus={user?.availability_status}
@@ -64,7 +66,9 @@ export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
                     size='2' />
                 <Heading size='5'>
                     <div className="flex items-center gap-2">
-                        {fullName ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)}
+                        {userName}
+                        {!user && <Badge color='gray' variant='soft'>Deleted</Badge>}
+                        {user?.enabled === 0 && <Badge color='gray' variant='soft'>Disabled</Badge>}
                         {user?.custom_status && <Badge color='gray' className='font-semibold px-1.5 py-0.5'>{user.custom_status}</Badge>}
                         {isUserOnLeave && <Badge color="yellow" variant="surface">On Leave</Badge>}
                         {isBot && <Badge color='gray' className='font-semibold px-1.5 py-0.5'>Bot</Badge>}

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -92,9 +92,7 @@ export const DirectMessageItemElement = ({ channel, unreadCount }: { channel: DM
     const showUnread = unreadCount && channelID !== channel.name
 
     if (!userData?.enabled) {
-        // If the user exists, but is not enabled, don't show the item
-
-        // If the user does not exist, we still show the item (probably a deleted user - maybe we shouldn't show it?)
+        // If the user does not exists or if the user exists, but is not enabled, don't show the item.
         return null
     }
 

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -91,6 +91,13 @@ export const DirectMessageItemElement = ({ channel, unreadCount }: { channel: DM
 
     const showUnread = unreadCount && channelID !== channel.name
 
+    if (userData && !userData.enabled) {
+        // If the user exists, but is not enabled, don't show the item
+
+        // If the user does not exist, we still show the item (probably a deleted user - maybe we shouldn't show it?)
+        return null
+    }
+
     return <SidebarItem to={channel.name} className={'py-0.5 px-2'}>
         <SidebarIcon>
             <UserAvatar src={userData?.user_image}

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -91,7 +91,7 @@ export const DirectMessageItemElement = ({ channel, unreadCount }: { channel: DM
 
     const showUnread = unreadCount && channelID !== channel.name
 
-    if (userData && !userData.enabled) {
+    if (!userData?.enabled) {
         // If the user exists, but is not enabled, don't show the item
 
         // If the user does not exist, we still show the item (probably a deleted user - maybe we shouldn't show it?)

--- a/frontend/src/components/layout/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/layout/EmptyState/EmptyState.tsx
@@ -82,14 +82,16 @@ const EmptyStateForDM = ({ channelData }: EmptyStateForDMProps) => {
 
     const isActive = useIsUserActive(peer)
 
+    const userName = fullName ?? peer ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)
+
     return (
         <Box className={'p-2'}>
             {channelData?.is_direct_message == 1 &&
                 <Flex direction='column' gap='3'>
                     <Flex gap='3' align='center'>
-                        <UserAvatar alt={fullName} src={userImage} size='3' skeletonSize='7' isBot={isBot} availabilityStatus={peerData?.availability_status} isActive={isActive} />
+                        <UserAvatar alt={userName} src={userImage} size='3' skeletonSize='7' isBot={isBot} availabilityStatus={peerData?.availability_status} isActive={isActive} />
                         <Flex direction='column' gap='0'>
-                            <Heading size='4'>{fullName ?? peer ?? replaceCurrentUserFromDMChannelName(channelData.channel_name, currentUser)}</Heading>
+                            <Heading size='4'>{userName}</Heading>
                             <div>
                                 {isBot ? <Badge color='gray' className="py-0 px-1">Bot</Badge> : <Text size='1' color='gray'>{peer}</Text>}
                             </div>

--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -122,7 +122,7 @@ def add_user_to_raven(doc, method):
 				raven_user = frappe.get_doc("Raven User", {"user": doc.name})
 				if not doc.full_name:
 					raven_user.full_name = doc.first_name
-				raven_user.enabled = 1
+				raven_user.enabled = doc.enabled
 				raven_user.save(ignore_permissions=True)
 			else:
 				raven_user = frappe.get_doc("Raven User", {"user": doc.name})
@@ -145,7 +145,7 @@ def add_user_to_raven(doc, method):
 						raven_user.user = doc.name
 						if not doc.full_name:
 							raven_user.full_name = doc.first_name
-						raven_user.enabled = 1
+						raven_user.enabled = doc.enabled
 						raven_user.insert(ignore_permissions=True)
 				else:
 					if "Raven User" in [d.role for d in doc.get("roles")]:
@@ -154,7 +154,7 @@ def add_user_to_raven(doc, method):
 						raven_user.user = doc.name
 						if not doc.full_name:
 							raven_user.full_name = doc.first_name
-						raven_user.enabled = 1
+						raven_user.enabled = doc.enabled
 						raven_user.insert(ignore_permissions=True)
 
 


### PR DESCRIPTION
1. If the "User" is disabled, disable the "Raven User".
2. If the Raven User is disabled, then do not show it on the sidebar. (Still searchable in the command menu)