### PR TITLE
fix: channel mentions with link

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "copy-html-entry": "cp ../raven/public/raven/index.html ../raven/www/raven.html"
   },
   "dependencies": {
-    "@radix-ui/themes": "^3.0.5",
+    "@radix-ui/themes": "^3.1.1",
     "@tiptap/extension-code-block-lowlight": "^2.4.0",
     "@tiptap/extension-highlight": "^2.4.0",
     "@tiptap/extension-image": "^2.4.0",

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Mention.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Mention.tsx
@@ -3,26 +3,12 @@ import { getStatusText } from '@/components/feature/userSettings/AvailabilitySta
 import { useGetUser } from '@/hooks/useGetUser';
 import { useIsUserActive } from '@/hooks/useIsUserActive';
 import { Flex, HoverCard, Link, Text } from '@radix-ui/themes';
-import Mention from '@tiptap/extension-mention'
-import { NodeViewRendererProps, NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
+import { NodeViewRendererProps, NodeViewWrapper } from "@tiptap/react";
 import { BsFillCircleFill } from 'react-icons/bs';
 import { Link as RouterLink } from 'react-router-dom';
 
-export const CustomUserMention = Mention.extend({
-    name: 'userMention',
-    addNodeView() {
-        return ReactNodeViewRenderer(UserMentionRenderer)
-    }
-})
 
-export const CustomChannelMention = Mention.extend({
-    name: 'channelMention',
-    addNodeView() {
-        return ReactNodeViewRenderer(ChannelMentionRenderer)
-    }
-})
-
-const UserMentionRenderer = ({ node }: NodeViewRendererProps) => {
+export const UserMentionRenderer = ({ node }: NodeViewRendererProps) => {
 
     const user = useGetUser(node.attrs.id)
     const isActive = useIsUserActive(node.attrs.id)
@@ -68,14 +54,15 @@ const UserMentionRenderer = ({ node }: NodeViewRendererProps) => {
 
 
 
-const ChannelMentionRenderer = ({ node }: NodeViewRendererProps) => {
+export const ChannelMentionRenderer = ({ node }: NodeViewRendererProps) => {
 
+    console.log(node)
 
     return (
         <NodeViewWrapper as={'span'}>
             <Link asChild>
-                <RouterLink to={`/channels/${node.attrs.id}`}>
-                    @{node.attrs.label}
+                <RouterLink to={`/channel/${node.attrs.id}`}>
+                    #{node.attrs.label}
                 </RouterLink>
             </Link>
         </NodeViewWrapper>

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Mention.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/Mention.tsx
@@ -56,8 +56,6 @@ export const UserMentionRenderer = ({ node }: NodeViewRendererProps) => {
 
 export const ChannelMentionRenderer = ({ node }: NodeViewRendererProps) => {
 
-    console.log(node)
-
     return (
         <NodeViewWrapper as={'span'}>
             <Link asChild>

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/tiptap-renderer.styles.css
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/tiptap-renderer.styles.css
@@ -3,3 +3,8 @@
     padding-left: 0.8rem;
     margin: 1rem;
 }
+
+.tiptap-renderer a,
+.tiptap-renderer .mention {
+    color: var(--accent-11);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,7 +2333,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.0.tgz#f817d1d3265ac5415dadc67edab30ae196696438"
   integrity sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==
 
-"@radix-ui/themes@^3.0.5":
+"@radix-ui/themes@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/themes/-/themes-3.1.1.tgz#a444f181975b8550f548c989ef3a432908c51075"
   integrity sha512-G+j+x+7kyqQXnn+ftlNPgk1DdZ8h/vVZnLsG4hZB0Mxw4fdKCh1tThQuXDSBNWhFt/vTG79BMzRMiflovENrmA==


### PR DESCRIPTION
Channel mentions show up with a link in messages now.

<img width="982" alt="image" src="https://github.com/user-attachments/assets/53ebabbe-f51e-4a11-a9a5-6f03e3cbfbdc">
