### PR TITLE
fix: correct parameter name for Raven User image

### DIFF
--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -95,7 +95,7 @@ class RavenUser(Document):
 					"doctype": "File",
 					"file_url": user_image,
 					"attached_to_doctype": "Raven User",
-					"attached_to_name": self.name,
+					"attached_to_name": self.user,
 					"attached_to_field": "user_image",
 					"is_private": 1,
 				}


### PR DESCRIPTION
Closes #1012 