### PR TITLE
fix(ux): show search button

### DIFF
--- a/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
@@ -1,8 +1,9 @@
 import { useTheme } from '@/ThemeProvider'
 import { commandMenuOpenAtom } from '@/components/feature/CommandMenu/CommandMenu'
-import { Flex, IconButton, Text } from '@radix-ui/themes'
-import { BiCommand, BiMoon, BiSun } from 'react-icons/bi'
+import { Flex, IconButton, Text, Tooltip } from '@radix-ui/themes'
+import { BiMoon, BiSearch, BiSun } from 'react-icons/bi'
 import { useSetAtom } from 'jotai'
+import { TbSearch } from 'react-icons/tb'
 
 export const SidebarHeader = () => {
     return (
@@ -14,7 +15,7 @@ export const SidebarHeader = () => {
                 pt='1'
                 height='48px'>
                 <Text as='span' size='6' className='cal-sans pl-1'>raven</Text>
-                <Flex align='center' gap='4' className='pr-1 sm:pr-0'>
+                <Flex align='center' gap='3' className='pr-1 sm:pr-0'>
                     <SearchButton />
                     <ColorModeToggleButton />
                 </Flex>
@@ -28,17 +29,19 @@ const SearchButton = () => {
     const setOpen = useSetAtom(commandMenuOpenAtom)
 
     return (
-        <IconButton
-            size={{ initial: '2', md: '1' }}
-            aria-label='Open command menu'
-            title='Open command menu'
-            color='gray'
-            className='text-gray-11 sm:hover:text-gray-12 sm:hidden'
-            variant='ghost'
-            onClick={() => setOpen(true)}
-        >
-            <BiCommand className='text-lg' />
-        </IconButton>
+        <Tooltip content="⌘+K">
+            <IconButton
+                size={{ initial: '2', md: '1' }}
+                aria-label='Open command menu'
+                title='Open command menu'
+                color='gray'
+                className='text-gray-11 sm:hover:text-gray-12'
+                variant='ghost'
+                onClick={() => setOpen(true)}
+            >
+                <TbSearch className='text-lg sm:text-base' />
+            </IconButton>
+        </Tooltip>
     )
 }
 

--- a/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@/ThemeProvider'
 import { commandMenuOpenAtom } from '@/components/feature/CommandMenu/CommandMenu'
 import { Flex, IconButton, Text, Tooltip } from '@radix-ui/themes'
-import { BiMoon, BiSearch, BiSun } from 'react-icons/bi'
+import { BiMoon, BiSun } from 'react-icons/bi'
 import { useSetAtom } from 'jotai'
 import { TbSearch } from 'react-icons/tb'
 


### PR DESCRIPTION
Show the search button in the header so that users can find it. Added a tooltip to mention the keyboard shortcut as well.

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/86a960fa-34dd-4d11-9e49-5169ce54381a">

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/ce26fbd2-96a6-47af-a70c-0bff4e072b8d">

