### PR TITLE
feat: translations

### DIFF
--- a/frontend/src/components/feature/channel-details/edit-channel-description/EditChannelDescriptionModal.tsx
+++ b/frontend/src/components/feature/channel-details/edit-channel-description/EditChannelDescriptionModal.tsx
@@ -6,6 +6,7 @@ import { Box, Dialog, Flex, Button, TextArea, Text } from "@radix-ui/themes"
 import { Loader } from "@/components/common/Loader"
 import { ErrorText, Label } from "@/components/common/Form"
 import { toast } from 'sonner'
+import { __ } from "@/utils/translations"
 
 interface RenameChannelForm {
     channel_description: string
@@ -30,7 +31,7 @@ export const EditChannelDescriptionModalContent = ({ channelData, onClose }: Ren
         updateDoc("Raven Channel", channelData?.name ?? null, {
             channel_description: data.channel_description
         }).then(() => {
-            toast.success("Channel description updated")
+            toast.success(__("Channel description updated"))
             onClose()
         })
     }
@@ -39,36 +40,36 @@ export const EditChannelDescriptionModalContent = ({ channelData, onClose }: Ren
         <FormProvider {...methods}>
             <form onSubmit={handleSubmit(onSubmit)}>
 
-                <Dialog.Title>{channelData && channelData?.channel_description && channelData?.channel_description.length > 0 ? 'Edit description' : 'Add description'}</Dialog.Title>
+                <Dialog.Title>{channelData && channelData?.channel_description && channelData?.channel_description.length > 0 ? __('Edit description') : __('Add description')}</Dialog.Title>
 
                 <Flex gap='2' direction='column' width='100%'>
                     <ErrorBanner error={error} />
                     <Box width='100%'>
-                        <Label htmlFor='channel_description'>Channel description</Label>
+                        <Label htmlFor='channel_description'>{__("Channel description")}</Label>
                         <TextArea
                             maxLength={140}
                             id='channel_description'
-                            placeholder='Add description'
+                            placeholder={__('Add description')}
                             {...register('channel_description', {
                                 maxLength: {
                                     value: 140,
-                                    message: "Channel description cannot be more than 200 characters."
+                                    message: __("Channel description cannot be more than 200 characters.")
                                 }
                             })}
                             aria-invalid={errors.channel_description ? 'true' : 'false'}
                         />
-                        <Text size='1' weight='light'>This is how people will know what this channel is about.</Text>
+                        <Text size='1' weight='light'>{__("This is how people will know what this channel is about.")}</Text>
                         {errors?.channel_description && <ErrorText>{errors.channel_description?.message}</ErrorText>}
                     </Box>
                 </Flex>
 
                 <Flex gap="3" mt="6" justify="end" align='center'>
                     <Dialog.Close disabled={updatingDoc}>
-                        <Button variant="soft" color="gray">Cancel</Button>
+                        <Button variant="soft" color="gray">{__("Cancel")}</Button>
                     </Dialog.Close>
                     <Button type='submit' disabled={updatingDoc}>
                         {updatingDoc && <Loader />}
-                        {updatingDoc ? "Saving" : "Save"}
+                        {updatingDoc ? __("Saving") : __("Save")}
                     </Button>
                 </Flex>
 

--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -12,6 +12,7 @@ import { RiPushpinLine, RiUnpinLine } from "react-icons/ri"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { RavenUser } from "@/types/Raven/RavenUser"
 import clsx from "clsx"
+import { __ } from "@/utils/translations"
 
 export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -64,7 +65,7 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
             <SidebarGroupItem className={'gap-1 pl-1'}>
                 <Flex width='100%' justify='between' align='center' gap='2' pr='2' className="group">
                     <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
-                        <SidebarGroupLabel>Channels</SidebarGroupLabel>
+                        <SidebarGroupLabel>{__("Channels")}</SidebarGroupLabel>
                         <Box className={clsx('transition-opacity ease-in-out duration-200',
                             !showData && unread_count && totalUnreadCount > 0 ? 'opacity-100' : 'opacity-0')}>
                             <SidebarBadge>
@@ -177,7 +178,7 @@ const PinButton = ({ channelID }: { channelID: string }) => {
             className='flex justify-start gap-2 min-w-24'
         >
             <RiUnpinLine size='18' />
-            Remove Pin
+            {__("Remove Pin")}
         </ContextMenu.Item>
     }
     return <ContextMenu.Item
@@ -185,7 +186,7 @@ const PinButton = ({ channelID }: { channelID: string }) => {
         className='flex justify-start gap-2 min-w-24'
     >
         <RiPushpinLine size='18' />
-        Pin
+        {__("Pin")}
     </ContextMenu.Item>
 
 }

--- a/frontend/src/components/feature/channels/CreateChannelModal.tsx
+++ b/frontend/src/components/feature/channels/CreateChannelModal.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { FiPlus } from 'react-icons/fi'
 import { useIsDesktop } from '@/hooks/useMediaQuery'
 import { Drawer, DrawerContent, DrawerTrigger } from '@/components/layout/Drawer'
+import { __ } from '@/utils/translations'
 
 interface ChannelCreationForm {
     channel_name: string,
@@ -102,7 +103,7 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
     const onSubmit = (data: ChannelCreationForm) => {
         createDoc('Raven Channel', data).then(result => {
             if (result) {
-                toast.success('Channel created')
+                toast.success(__("Channel created"))
                 onClose(result.name)
             }
         })
@@ -117,20 +118,20 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
             case 'Private':
                 return {
                     channelIcon: <BiLockAlt />,
-                    header: 'Create a private channel',
-                    helperText: 'When a channel is set to private, it can only be viewed or joined by invitation.'
+                    header: __("Create a private channel"),
+                    helperText: __('When a channel is set to private, it can only be viewed or joined by invitation.')
                 }
             case 'Open':
                 return {
                     channelIcon: <BiGlobe />,
-                    header: 'Create an open channel',
-                    helperText: 'When a channel is set to open, everyone is a member.'
+                    header: __("Create an open channel"),
+                    helperText: __('When a channel is set to open, everyone is a member.')
                 }
             default:
                 return {
                     channelIcon: <BiHash />,
-                    header: 'Create a public channel',
-                    helperText: 'When a channel is set to public, anyone can join the channel and read messages, but only members can post messages.'
+                    header: __('Create a public channel'),
+                    helperText: __('When a channel is set to public, anyone can join the channel and read messages, but only members can post messages.')
                 }
         }
     }, [channelType])
@@ -143,32 +144,32 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
             {header}
         </Dialog.Title>
         <Dialog.Description size='2'>
-            Channels are where your team communicates. They are best when organized around a topic - #development, for example.
+            {__("Channels are where your team communicates. They are best when organized around a topic - #development, for example.")}
         </Dialog.Description>
         <FormProvider {...methods}>
             <form onSubmit={handleSubmit(onSubmit)}>
                 <Flex direction='column' gap='4' py='4'>
                     <ErrorBanner error={channelCreationError} />
                     <Box>
-                        <Label htmlFor='channel_name' isRequired>Name</Label>
+                        <Label htmlFor='channel_name' isRequired>{__("Name")}</Label>
                         <Controller
                             name='channel_name'
                             control={control}
                             rules={{
-                                required: "Please add a channel name",
+                                required: __("Please add a channel name"),
                                 maxLength: {
                                     value: 50,
-                                    message: "Channel name cannot be more than 50 characters."
+                                    message: __("Channel name cannot be more than {0} characters.", ["50"])
                                 },
                                 minLength: {
                                     value: 3,
-                                    message: "Channel name cannot be less than 3 characters."
+                                    message: __("Channel name cannot be less than {0} characters.", ["3"])
                                 },
                                 pattern: {
                                     // no special characters allowed
                                     // cannot start with a space
                                     value: /^[a-zA-Z0-9][a-zA-Z0-9-]*$/,
-                                    message: "Channel name can only contain letters, numbers and hyphens."
+                                    message: __("Channel name can only contain letters, numbers and hyphens.")
                                 }
                             }}
                             render={({ field, fieldState: { error } }) => (
@@ -194,7 +195,7 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
                     </Box>
 
                     <Box>
-                        <Label htmlFor='channel_description'>Description <Text as='span' weight='light'>(optional)</Text></Label>
+                        <Label htmlFor='channel_description'>{__("Description")} <Text as='span' weight='light'>({__("optional")})</Text></Label>
                         <TextArea
                             maxLength={140}
                             id='channel_description'
@@ -202,7 +203,7 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
                             {...register('channel_description', {
                                 maxLength: {
                                     value: 140,
-                                    message: "Channel description cannot be more than 140 characters."
+                                    message: __("Channel description cannot be more than {0} characters.", ["140"])
                                 }
                             })}
                             aria-invalid={errors.channel_description ? 'true' : 'false'}
@@ -225,17 +226,17 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
                                     <Flex gap="4">
                                         <Text as="label" size="2">
                                             <Flex gap="2">
-                                                <RadioGroup.Item value="Public" /> Public
+                                                <RadioGroup.Item value="Public" /> {__("Public")}
                                             </Flex>
                                         </Text>
                                         <Text as="label" size="2">
                                             <Flex gap="2">
-                                                <RadioGroup.Item value="Private" /> Private
+                                                <RadioGroup.Item value="Private" /> {__("Private")}
                                             </Flex>
                                         </Text>
                                         <Text as="label" size="2">
                                             <Flex gap="2">
-                                                <RadioGroup.Item value="Open" /> Open
+                                                <RadioGroup.Item value="Open" /> {__("Open")}
                                             </Flex>
                                         </Text>
                                     </Flex>
@@ -251,12 +252,12 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
                 <Flex gap="3" mt="4" justify="end">
                     <Dialog.Close disabled={creatingChannel}>
                         <Button variant="soft" color="gray">
-                            Cancel
+                            {__("Cancel")}
                         </Button>
                     </Dialog.Close>
                     <Button type='submit' disabled={creatingChannel}>
                         {creatingChannel && <Loader />}
-                        {creatingChannel ? "Saving" : "Save"}
+                        {creatingChannel ? __("Saving") : __("Save")}
                     </Button>
                 </Flex>
             </form>

--- a/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
+++ b/frontend/src/components/feature/direct-messages/DirectMessageList.tsx
@@ -15,6 +15,7 @@ import { useStickyState } from "@/hooks/useStickyState"
 import clsx from "clsx"
 import { UserFields, UserListContext } from "@/utils/users/UserListProvider"
 import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
+import { __ } from "@/utils/translations"
 
 export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -37,7 +38,7 @@ export const DirectMessageList = ({ unread_count }: { unread_count?: UnreadCount
             <SidebarGroupItem className={'gap-1 pl-1'}>
                 <Flex width='100%' justify='between' align='center' gap='2' pr='2' className="group">
                     <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
-                        <SidebarGroupLabel className="pt-0.5">Members</SidebarGroupLabel>
+                        <SidebarGroupLabel className="pt-0.5">{__("Members")}</SidebarGroupLabel>
                         <Box className={clsx('transition-opacity ease-in-out duration-200', !showData && unread_count && unread_count?.total_unread_count_in_dms > 0 ? 'opacity-100' : 'opacity-0')}>
                             <SidebarBadge>{unread_count?.total_unread_count_in_dms}</SidebarBadge>
                         </Box>
@@ -137,7 +138,7 @@ const ExtraUsersItemList = () => {
                 mutate()
             })
             .catch((e) => {
-                toast.error('Could not create channel', {
+                toast.error(__("Could not create channel"), {
                     description: getErrorMessage(e)
                 })
             })

--- a/frontend/src/components/feature/userSettings/AvailabilityStatus/SetUserAvailabilityMenu.tsx
+++ b/frontend/src/components/feature/userSettings/AvailabilityStatus/SetUserAvailabilityMenu.tsx
@@ -8,6 +8,7 @@ import { DropdownMenu, Flex } from '@radix-ui/themes'
 import { useUserData } from '@/hooks/useUserData'
 import { GrPowerReset } from 'react-icons/gr'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
+import { __ } from '@/utils/translations'
 
 export type AvailabilityStatus = 'Available' | 'Away' | 'Do not disturb' | 'Invisible' | ''
 
@@ -24,7 +25,7 @@ export const SetUserAvailabilityMenu = () => {
             fieldname: 'availability_status',
             value: status
         }).then(() => {
-            toast.success("User availability updated")
+            toast.success(__("User availability updated"))
             mutate()
         })
     }, [userData.name])
@@ -49,7 +50,7 @@ export const SetUserAvailabilityMenu = () => {
                     {getStatusText('Invisible')}
                 </DropdownMenu.Item>
                 <DropdownMenu.Item className={'flex justify-normal gap-2'} color='gray' onClick={() => setAvailabilityStatus('')}>
-                    <GrPowerReset fontSize={'0.7rem'} /> Reset
+                    <GrPowerReset fontSize={'0.7rem'} /> {__("Reset")}
                 </DropdownMenu.Item>
             </DropdownMenu.SubContent>
         </DropdownMenu.Sub>
@@ -59,14 +60,14 @@ export const SetUserAvailabilityMenu = () => {
 export const getStatusText = (status: AvailabilityStatus) => {
     switch (status) {
         case 'Available':
-            return <><BiSolidCircle color={'green'} fontSize={'0.7rem'} /> Available</>
+            return <><BiSolidCircle color={'green'} fontSize={'0.7rem'} /> {__("Available")}</>
         case 'Away':
-            return <><MdWatchLater color={'#FFAA33'} fontSize={'0.8rem'} /> Away</>
+            return <><MdWatchLater color={'#FFAA33'} fontSize={'0.8rem'} /> {__("Away")}</>
         case 'Do not disturb':
-            return <><FaCircleMinus color={'#D22B2B'} fontSize={'0.7rem'} /> Do not disturb</>
+            return <><FaCircleMinus color={'#D22B2B'} fontSize={'0.7rem'} /> {__("Do not disturb")}</>
         case 'Invisible':
-            return <><FaCircleDot className={'text-gray-400'} fontSize={'0.7rem'} /> Invisible</>
+            return <><FaCircleDot className={'text-gray-400'} fontSize={'0.7rem'} /> {__("Invisible")}</>
         default:
-            return <><BiSolidCircle color={'green'} fontSize={'0.7rem'} /> Available</>
+            return <><BiSolidCircle color={'green'} fontSize={'0.7rem'} /> {__("Available")}</>
     }
 }

--- a/frontend/src/components/feature/userSettings/CustomStatus/SetCustomStatusContent.tsx
+++ b/frontend/src/components/feature/userSettings/CustomStatus/SetCustomStatusContent.tsx
@@ -4,7 +4,8 @@ import { Loader } from '@/components/common/Loader'
 import { ErrorBanner } from '@/components/layout/AlertBanner'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
 import { useUserData } from '@/hooks/useUserData'
-import { Button, Dialog, Flex, TextField, Text, IconButton } from '@radix-ui/themes'
+import { __ } from '@/utils/translations'
+import { Button, Dialog, Flex, TextField, IconButton } from '@radix-ui/themes'
 import { useFrappePostCall } from 'frappe-react-sdk'
 import { useCallback, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -31,7 +32,7 @@ const SetCustomStatusContent = ({ onClose }: { onClose: VoidFunction }) => {
             fieldname: 'custom_status',
             value: data.custom_status
         }).then(() => {
-            toast.success("User status updated")
+            toast.success(__("User status updated"))
             mutate()
             onClose()
         })
@@ -45,14 +46,14 @@ const SetCustomStatusContent = ({ onClose }: { onClose: VoidFunction }) => {
 
     return (
         <>
-            <Dialog.Title>Set a custom status</Dialog.Title>
+            <Dialog.Title>{__("Set a custom status")}</Dialog.Title>
             <FormProvider {...methods}>
                 <form onSubmit={handleSubmit(onSubmit)}>
 
                     <ErrorBanner error={error} />
 
                     <Flex direction={'column'} gap={'2'}>
-                        <Label size='2' color='gray' weight='regular' htmlFor='custom_status'>Share what you're up to</Label>
+                        <Label size='2' color='gray' weight='regular' htmlFor='custom_status'>{__("Share what you're up to")}</Label>
                         <Flex align={'center'} gap='3'>
                             <Flex direction={'column'} gap='1'>
                                 <TextField.Root
@@ -63,7 +64,7 @@ const SetCustomStatusContent = ({ onClose }: { onClose: VoidFunction }) => {
                                     {...register('custom_status', {
                                         maxLength: {
                                             value: 140,
-                                            message: "Status cannot be more than 140 characters."
+                                            message: __("Status cannot be more than {0} characters.", 140)
                                         }
                                     })}
                                     className='min-w-[21rem]'
@@ -84,11 +85,11 @@ const SetCustomStatusContent = ({ onClose }: { onClose: VoidFunction }) => {
 
                     <Flex gap="3" mt="6" justify="end" align='center'>
                         <Dialog.Close disabled={loading}>
-                            <Button variant="soft" color="gray">Cancel</Button>
+                            <Button variant="soft" color="gray">{__("Cancel")}</Button>
                         </Dialog.Close>
                         <Button type='submit' disabled={loading}>
                             {loading && <Loader />}
-                            {loading ? "Saving" : "Save"}
+                            {loading ? __("Saving") : __("Save")}
                         </Button>
                     </Flex>
                 </form>

--- a/frontend/src/components/feature/userSettings/PushNotifications/PushNotificationToggle.tsx
+++ b/frontend/src/components/feature/userSettings/PushNotifications/PushNotificationToggle.tsx
@@ -1,5 +1,6 @@
 import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
 import useIsPushNotificationEnabled from '@/hooks/fetchers/useIsPushNotificationEnabled'
+import { __ } from '@/utils/translations'
 import { DropdownMenu } from '@radix-ui/themes'
 import { useState } from 'react'
 import { BsBell, BsBellSlash } from 'react-icons/bs'
@@ -23,10 +24,10 @@ const PushNotificationToggle = (props: Props) => {
                 .disableNotification()
                 .then((data: any) => {
                     setPushNotificationsEnabled(false) // Disable the switch
-                    toast.info("Push notifications disabled")
+                    toast.info(__("Push notifications disabled"))
                 })
                 .catch((error: any) => {
-                    toast.error("There was an error", {
+                    toast.error(__("There was an error"), {
                         description: getErrorMessage(error)
                     }
                     )
@@ -54,8 +55,8 @@ const PushNotificationToggle = (props: Props) => {
                     throw error
                 })
             , {
-                success: "Push notifications enabled",
-                loading: "Enabling...",
+                success: __("Push notifications enabled"),
+                loading: __("Enabling..."),
                 error: (e: Error) => e.message
             })
     }
@@ -68,7 +69,7 @@ const PushNotificationToggle = (props: Props) => {
         <DropdownMenu.Item color='gray'
             onClick={togglePushNotifications}
             className={'flex justify-normal gap-2'}>
-            {pushNotificationsEnabled ? <><BsBellSlash size='14' /> Disable Notifications</> : <><BsBell size='14' /> Enable Notifications</>}
+            {pushNotificationsEnabled ? <><BsBellSlash size='14' /> {__("Disable Notifications")}</> : <><BsBell size='14' /> {__("Enable Notifications")}</>}
         </DropdownMenu.Item>
     )
 }

--- a/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
+++ b/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useIsDesktop } from '@/hooks/useMediaQuery'
+import { __ } from '@/utils/translations'
 import { Box, Flex, Separator, Text } from '@radix-ui/themes'
 import clsx from 'clsx'
 import { PropsWithChildren, createElement } from 'react'
@@ -9,8 +9,6 @@ import { LuUserCircle2 } from 'react-icons/lu'
 import { NavLink } from 'react-router-dom'
 
 export const SettingsSidebar = () => {
-
-    const isDesktop = useIsDesktop()
 
     return (
         <Box className="h-[full] w-64 border-r border-gray-4  dark:border-gray-6">
@@ -58,7 +56,7 @@ const SettingsSidebarGroupHeader = ({ title, icon }: { title: string, icon: Icon
     return (
         <Flex className="py-1.5 flex items-center gap-1.5 text-gray-11">
             {createElement(icon, { size: 15 })}
-            <Text size='1'>{title}</Text>
+            <Text size='1'>{__(title)}</Text>
         </Flex>
     )
 }
@@ -77,7 +75,7 @@ const SettingsSidebarItem = ({ title, to, end }: { title: string, to: string, en
                 return (
                     <Box className='ml-4'>
                         <Flex className={clsx(`px-2 py-1 text-gray-12 rounded-md w-full`, isActive ? activeClass : "bg-transparent hover:bg-slate-2 hover:dark:bg-slate-3")}>
-                            <Text className='text-[13px]' weight='medium'>{title}</Text>
+                            <Text className='text-[13px]' weight='medium'>{__(title)}</Text>
                         </Flex>
                     </Box>
                 )

--- a/frontend/src/components/feature/userSettings/UploadImage/DeleteImageModal.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/DeleteImageModal.tsx
@@ -4,6 +4,7 @@ import { AlertDialog, Button, Flex, Text } from '@radix-ui/themes'
 import { ErrorBanner } from '@/components/layout/AlertBanner'
 import { Loader } from '@/components/common/Loader'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
+import { __ } from '@/utils/translations'
 
 interface DeleteImageModalProps {
     onClose: () => void
@@ -29,23 +30,23 @@ export const DeleteImageModal = ({ onClose }: DeleteImageModalProps) => {
 
     return (
         <>
-            <AlertDialog.Title>Remove Image</AlertDialog.Title>
+            <AlertDialog.Title>{__("Remove Image")}</AlertDialog.Title>
 
             <Flex direction={'column'} gap='2'>
                 <ErrorBanner error={error} />
-                <Text>Are you sure you want to remove this image?</Text>
+                <Text>{__("Are you sure you want to remove this image?")}</Text>
             </Flex>
 
             <Flex gap="3" mt="4" justify="end">
                 <AlertDialog.Cancel>
                     <Button variant="soft" color="gray">
-                        Cancel
+                        {__("Cancel")}
                     </Button>
                 </AlertDialog.Cancel>
                 <AlertDialog.Action>
                     <Button variant="solid" color="red" onClick={removeImage} disabled={loading}>
                         {loading && <Loader />}
-                        {loading ? "Removing" : "Remove"}
+                        {loading ? __("Removing") : __("Remove")}
                     </Button>
                 </AlertDialog.Action>
             </Flex>

--- a/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
@@ -1,5 +1,4 @@
-import { Button, Flex, IconButton, Text } from "@radix-ui/themes";
-import { FlexProps } from "@radix-ui/themes/dist/cjs/components/flex";
+import { Button, Flex, FlexProps, IconButton, Text } from "@radix-ui/themes";
 import { forwardRef, useImperativeHandle, useState } from "react";
 import { Accept, useDropzone } from "react-dropzone";
 import { toast } from "sonner";
@@ -9,8 +8,9 @@ import { BiTrash } from "react-icons/bi";
 import { CustomFile } from "../../file-upload/FileDrop";
 import { FileUploadProgress } from "../../chat/ChatInput/FileInput/useFileUpload";
 import { getFileSize } from "../../file-upload/FileListItem";
+import { __ } from "@/utils/translations";
 
-export interface FileUploadBoxProps extends FlexProps {
+export type FileUploadBoxProps = FlexProps & {
     /** File to be uploaded */
     file: CustomFile | undefined
     /** Function to set file in parent */
@@ -28,10 +28,10 @@ export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
 
     const fileSizeValidator = (file: any) => {
         if (maxFileSize && file.size > maxFileSize * 1000000) {
-            toast.error(`Uh Oh! ${file.name} exceeded the maximum file size required.`)
+            toast.error(__("Uh Oh! {0} exceeded the maximum file size required.", [file.name]))
             return {
                 code: "size-too-large",
-                message: `File size is larger than the required size.`,
+                message: __("File size is larger than the required size."),
             }
         } else return null
     }
@@ -86,20 +86,20 @@ export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
                 display={"flex"}>
                 <Flex gap={'1'}>
                     <Text as="span" size="2" color="gray">
-                        Drag and drop your file here or
+                        {__("Drag and drop your file here or")}
                     </Text>
                     <Button variant={'ghost'} onClick={open} className={"underline not-cal hover:bg-transparent cursor-pointer"}>
-                        choose file
+                        {__("choose file")}
                     </Button>
                 </Flex>
                 <input type="file" style={{ display: "none" }} {...getInputProps()} />
             </Flex>
             <Flex justify={'between'}>
                 <Text as="span" size="1" color="gray">
-                    Supported formats: .jpeg, .jpg, .png
+                    {__("Supported formats: {0}, {1}, {2}", [".jpeg", ".jpg", ".png"])}
                 </Text>
                 <Text as="span" size="1" color="gray">
-                    Maximum file size: 10MB
+                    {__("Maximum file size: {0}MB", [10])}
                 </Text>
             </Flex>
             {file && <FileItem file={file} uploadProgress={fileUploadProgress} removeFile={() => removeFile(file.fileID)} />}

--- a/frontend/src/components/feature/userSettings/UploadImage/ImageUploader.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/ImageUploader.tsx
@@ -10,6 +10,7 @@ import { FiCamera } from "react-icons/fi"
 import { BiSolidTrash } from "react-icons/bi"
 import { UserAvatar, getInitials } from "@/components/common/UserAvatar"
 import useCurrentRavenUser from "@/hooks/useCurrentRavenUser"
+import { __ } from "@/utils/translations"
 
 interface ImageUploaderProps {
     /** Takes input MIME type as 'key' & array of extensions as 'value'; empty array - all extensions supported */
@@ -32,7 +33,7 @@ export const ImageUploader = ({ icon, accept = { 'image/*': ['.jpeg', '.jpg', '.
                 fieldname: 'user_image',
                 value: file
             }).then(() => {
-                toast("Image uploaded successfully.")
+                toast(__("Image uploaded successfully."))
                 mutate()
             }).catch(() => {
                 toast(`There was an error while uploading the image. ${error ? error.exception ?? error.httpStatusText : null}`)

--- a/frontend/src/components/feature/userSettings/UploadImage/UploadImageModal.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/UploadImageModal.tsx
@@ -6,6 +6,7 @@ import { ErrorBanner } from "@/components/layout/AlertBanner"
 import { useState } from "react"
 import { FrappeError, useFrappeFileUpload } from "frappe-react-sdk"
 import { FileUploadBox } from "./FileUploadBox"
+import { __ } from "@/utils/translations"
 
 interface UploadImageModalProps {
     onClose: () => void,
@@ -43,7 +44,7 @@ export const UploadImageModal = ({ onClose, uploadImage }: UploadImageModalProps
 
     return (
         <>
-            <Dialog.Title>Upload file</Dialog.Title>
+            <Dialog.Title>{__("Upload file")}</Dialog.Title>
 
             <ErrorBanner error={fileError} />
 
@@ -56,11 +57,11 @@ export const UploadImageModal = ({ onClose, uploadImage }: UploadImageModalProps
 
             <Flex gap="3" mt="6" justify="end" align='center'>
                 <Dialog.Close disabled={loading}>
-                    <Button variant="soft" color="gray">Cancel</Button>
+                    <Button variant="soft" color="gray">{__("Cancel")}</Button>
                 </Dialog.Close>
                 <Button type='button' onClick={uploadFiles} disabled={loading}>
                     {loading && <Loader />}
-                    {loading ? "Saving" : "Save"}
+                    {loading ? __("Saving") : __("Save")}
                 </Button>
             </Flex>
         </>

--- a/frontend/src/components/feature/userSettings/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/feature/userSettings/UserProfile/UserProfile.tsx
@@ -16,6 +16,7 @@ import { useIsDesktop } from "@/hooks/useMediaQuery"
 import PageContainer from "@/components/layout/Settings/PageContainer"
 import SettingsPageHeader from "@/components/layout/Settings/SettingsPageHeader"
 import SettingsContentContainer from "@/components/layout/Settings/SettingsContentContainer"
+import { __ } from "@/utils/translations"
 
 type UserProfile = {
     full_name?: string,
@@ -47,10 +48,10 @@ const UserProfile = () => {
             availability_status: availabilityStatus,
             custom_status: data.custom_status
         }).then(() => {
-            toast.success("Profile updated")
+            toast.success(__("Profile updated"))
             mutate()
         }).catch(() => {
-            toast.error("Profile update failed")
+            toast.error(__("Profile update failed"))
         })
     }
 
@@ -67,11 +68,11 @@ const UserProfile = () => {
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <SettingsContentContainer>
                         <SettingsPageHeader
-                            title='Profile'
-                            description='Manage your Raven profile'
+                            title={__('Profile')}
+                            description={__('Manage your Raven profile')}
                             actions={<Button type='submit' disabled={updatingDoc}>
                                 {updatingDoc && <Loader />}
-                                {updatingDoc ? "Saving" : "Save"}
+                                {updatingDoc ? __("Saving") : __("Save")}
                             </Button>}
                         />
 
@@ -87,7 +88,7 @@ const UserProfile = () => {
                                 <Flex gap='4' direction='column' className={'py-4 px-6 dark:bg-slate-2'}>
 
                                     <Flex justify={'between'} align={'center'}>
-                                        <Label htmlFor='full_name'>Full Name</Label>
+                                        <Label htmlFor='full_name'>{__("Full Name")}</Label>
                                         <TextField.Root
                                             autoFocus
                                             maxLength={140}
@@ -97,7 +98,7 @@ const UserProfile = () => {
                                             {...register('full_name', {
                                                 maxLength: {
                                                     value: 140,
-                                                    message: "Name cannot be more than 140 characters."
+                                                    message: __("Name cannot be more than {0} characters.", [140])
                                                 }
                                             })}
                                             aria-invalid={errors.full_name ? 'true' : 'false'}
@@ -108,11 +109,11 @@ const UserProfile = () => {
                                     <Separator className={'w-full bg-slate-4'} />
 
                                     <Flex justify={'between'} align={'center'}>
-                                        <Label htmlFor="availability_status">Availability Status</Label>
+                                        <Label htmlFor="availability_status">{__("Availability Status")}</Label>
                                         <DropdownMenu.Root>
                                             <DropdownMenu.Trigger>
                                                 <Flex gap={'2'} align='center' className={'text-sm px-2 py-1 border border-gray-7 rounded w-48 sm:w-96'}>{availabilityStatus ? getStatusText(availabilityStatus) :
-                                                    <Text color="gray">Set Availability</Text>
+                                                    <Text color="gray">{__("Set Availability")}</Text>
                                                 }</Flex>
                                             </DropdownMenu.Trigger>
                                             <DropdownMenu.Content variant="soft">
@@ -129,7 +130,7 @@ const UserProfile = () => {
                                                     {getStatusText('Invisible')}
                                                 </DropdownMenu.Item>
                                                 <DropdownMenu.Item className={'flex justify-normal gap-2'} color='gray' onClick={() => setAvailabilityStatus('')}>
-                                                    <GrPowerReset fontSize={'0.7rem'} /> Reset
+                                                    <GrPowerReset fontSize={'0.7rem'} /> {__("Reset")}
                                                 </DropdownMenu.Item>
                                             </DropdownMenu.Content>
                                         </DropdownMenu.Root>
@@ -139,8 +140,8 @@ const UserProfile = () => {
 
                                     <Flex justify={'between'} align={'center'}>
                                         <Flex direction={'column'} gap='0'>
-                                            <Label htmlFor='custom_status'>Custom Status</Label>
-                                            {isDesktop && <Text size={'1'} color={'gray'} style={{ lineHeight: '0.8' }}>Share what you are up to</Text>}
+                                            <Label htmlFor='custom_status'>{__("Custom Status")}</Label>
+                                            {isDesktop && <Text size={'1'} color={'gray'} style={{ lineHeight: '0.8' }}>{__("Share what you are up to")}</Text>}
                                         </Flex>
                                         <Flex align={'center'} gap='3'>
                                             <Flex direction={'column'} gap='1'>
@@ -151,7 +152,7 @@ const UserProfile = () => {
                                                     {...register('custom_status', {
                                                         maxLength: {
                                                             value: 140,
-                                                            message: "Status cannot be more than 140 characters."
+                                                            message: __("Status cannot be more than {} characters.", ["140"])
                                                         }
                                                     })}
                                                     className={'w-48 sm:w-96'}

--- a/frontend/src/components/layout/Sidebar/PinnedChannels.tsx
+++ b/frontend/src/components/layout/Sidebar/PinnedChannels.tsx
@@ -4,6 +4,7 @@ import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList } f
 import { Box, Flex } from '@radix-ui/themes'
 import { ChannelItemElement } from '@/components/feature/channels/ChannelList'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
+import { __ } from '@/utils/translations'
 
 const PinnedChannels = ({ unread_count }: { unread_count?: UnreadCountData }) => {
 
@@ -38,7 +39,7 @@ const PinnedChannels = ({ unread_count }: { unread_count?: UnreadCountData }) =>
         <Box>
             <SidebarGroup>
                 <SidebarGroupItem className={'gap-1 pl-1'}>
-                    <SidebarGroupLabel className='cal-sans'>Pinned</SidebarGroupLabel>
+                    <SidebarGroupLabel className='cal-sans'>{__("Pinned")}</SidebarGroupLabel>
                 </SidebarGroupItem>
                 <SidebarGroup>
                     <SidebarGroupList>

--- a/frontend/src/components/layout/Sidebar/SidebarBody.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarBody.tsx
@@ -6,6 +6,7 @@ import useUnreadMessageCount from '@/hooks/useUnreadMessageCount'
 import PinnedChannels from './PinnedChannels'
 import React from 'react'
 import { BiBookmark, BiMessageAltDetail } from 'react-icons/bi'
+import { __ } from '@/utils/translations'
 
 export const SidebarBody = () => {
 
@@ -45,14 +46,14 @@ const SidebarItemForPage = ({ to, label, icon, iconLabel }: SidebarItemForPagePr
     return (
         <Box>
             <SidebarItem to={to} className='py-1 px-[10px]'>
-                <AccessibleIcon label={iconLabel}>
+                <AccessibleIcon label={__(iconLabel)}>
                     {icon}
                 </AccessibleIcon>
                 <Box>
                     <Text size={{
                         initial: '3',
                         md: '2'
-                    }} className='text-gray-12 dark:text-gray-300 font-semibold'>{label}</Text>
+                    }} className='text-gray-12 dark:text-gray-300 font-semibold'>{__(label)}</Text>
                 </Box>
             </SidebarItem>
         </Box>

--- a/frontend/src/components/layout/Sidebar/SidebarComp.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarComp.tsx
@@ -5,6 +5,7 @@ import { IconButtonProps } from '@radix-ui/themes/dist/cjs/components/icon-butto
 import { BadgeProps } from '@radix-ui/themes/dist/cjs/components/badge';
 import { clsx } from 'clsx';
 import { FiChevronDown, FiChevronRight } from 'react-icons/fi';
+import { __ } from '@/utils/translations';
 
 type SidebarGroupProps = FlexProps & {
     children: ReactNode;
@@ -141,8 +142,8 @@ export const SidebarViewMoreButton = ({ expanded, onClick, ...props }: SidebarVi
 
     return (
         <IconButton
-            aria-label={expanded ? 'Collapse' : "Expand"}
-            title={expanded ? 'Collapse' : "Expand"}
+            aria-label={expanded ? __("Collapse") : __("Expand")}
+            title={expanded ? __("Collapse") : __("Expand")}
             variant='soft'
             size='1'
             radius='large'

--- a/frontend/src/components/layout/Sidebar/SidebarFooter.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarFooter.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom'
 import { SetUserAvailabilityMenu } from '@/components/feature/userSettings/AvailabilityStatus/SetUserAvailabilityMenu'
 import { SetCustomStatusModal } from '@/components/feature/userSettings/CustomStatus/SetCustomStatusModal'
 import PushNotificationToggle from '@/components/feature/userSettings/PushNotifications/PushNotificationToggle'
+import { __ } from '@/utils/translations'
 
 export const SidebarFooter = () => {
 
@@ -54,12 +55,12 @@ export const SidebarFooter = () => {
                             <DropdownMenu.Content variant='soft'>
                                 <SetUserAvailabilityMenu />
                                 <DropdownMenu.Item color='gray' className={'flex justify-normal gap-2'} onClick={() => setUserStatusModalOpen(true)}>
-                                    <BsEmojiSmile size='14' /> Set custom status
+                                    <BsEmojiSmile size='14' /> {__("Set custom status")}
                                 </DropdownMenu.Item>
                                 <PushNotificationToggle />
                                 <DropdownMenu.Separator />
                                 <DropdownMenu.Item color='red' className={'flex justify-normal gap-2'} onClick={logout}>
-                                    <MdOutlineExitToApp size='14' />Log Out
+                                    <MdOutlineExitToApp size='14' /> {__("Log Out")}
                                 </DropdownMenu.Item>
                             </DropdownMenu.Content>
                         </DropdownMenu.Root>

--- a/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarHeader.tsx
@@ -4,6 +4,7 @@ import { Flex, IconButton, Text, Tooltip } from '@radix-ui/themes'
 import { BiMoon, BiSun } from 'react-icons/bi'
 import { useSetAtom } from 'jotai'
 import { TbSearch } from 'react-icons/tb'
+import { __ } from '@/utils/translations'
 
 export const SidebarHeader = () => {
     return (
@@ -33,7 +34,7 @@ const SearchButton = () => {
             <IconButton
                 size={{ initial: '2', md: '1' }}
                 aria-label='Open command menu'
-                title='Open command menu'
+                title={__("Open command menu")}
                 color='gray'
                 className='text-gray-11 sm:hover:text-gray-12'
                 variant='ghost'
@@ -53,7 +54,7 @@ const ColorModeToggleButton = () => {
         <IconButton
             size={{ initial: '2', md: '1' }}
             aria-label='Toggle theme'
-            title='Toggle theme'
+            title={__("Toggle theme")}
             color='gray'
             className='text-gray-11 sm:hover:text-gray-12'
             variant='ghost'

--- a/frontend/src/pages/settings/Integrations/FrappeHR.tsx
+++ b/frontend/src/pages/settings/Integrations/FrappeHR.tsx
@@ -6,6 +6,7 @@ import SettingsContentContainer from '@/components/layout/Settings/SettingsConte
 import SettingsPageHeader from '@/components/layout/Settings/SettingsPageHeader'
 import useRavenSettings from '@/hooks/fetchers/useRavenSettings'
 import { RavenSettings } from '@/types/Raven/RavenSettings'
+import { __ } from '@/utils/translations'
 import { Button, Checkbox, Flex, Select, Separator, Text } from '@radix-ui/themes'
 import { useFrappeUpdateDoc } from 'frappe-react-sdk'
 import { useEffect } from 'react'
@@ -40,9 +41,9 @@ const FrappeHR = () => {
         }), {
             loading: 'Updating...',
             success: () => {
-                return `Settings updated`;
+                return __("Settings updated");
             },
-            error: 'There was an error.',
+            error: __("There was an error."),
         })
 
     }
@@ -58,17 +59,17 @@ const FrappeHR = () => {
                 <form onSubmit={handleSubmit(onSubmit)}>
                     <SettingsContentContainer>
                         <SettingsPageHeader
-                            title='HR'
-                            description='Connect your HR system to Raven to sync employee data and send notifications.'
+                            title={__('HR')}
+                            description={__("Connect your HR system to Raven to sync employee data and send notifications.")}
                             actions={<Button type='submit' disabled={updatingDoc}>
                                 {updatingDoc && <Loader />}
-                                {updatingDoc ? "Saving" : "Save"}
+                                {updatingDoc ? __("Saving") : __("Save")}
                             </Button>}
                         />
                         {!isHRInstalled && <CustomCallout
                             iconChildren={<FiAlertTriangle />}
                             rootProps={{ color: 'yellow', variant: 'surface' }}
-                            textChildren="HR is not installed on this site.">
+                            textChildren={__("HR is not installed on this site.")} >
                         </CustomCallout>}
 
                         <Flex direction={'column'} gap='2' maxWidth={'480px'}>
@@ -85,16 +86,16 @@ const FrappeHR = () => {
                                             />
                                         )} />
 
-                                    Automatically create channels for departments
+                                    {__("Automatically create channels for departments")}
                                 </Flex>
                             </Text>
                             <HelperText>
-                                If checked, a channel will be created for each department. Employees in the department will be synced with channel members.
+                                {__("If checked, a channel will be created for each department. Employees in the department will be synced with channel members.")}
                             </HelperText>
                         </Flex>
                         {autoCreateDepartment ?
                             <Flex direction={'column'} maxWidth={'320px'}>
-                                <Label isRequired>Department Channel Type</Label>
+                                <Label isRequired>{__("Department Channel Type")}</Label>
                                 <Controller
                                     control={control}
                                     defaultValue={ravenSettings?.department_channel_type}
@@ -106,10 +107,10 @@ const FrappeHR = () => {
                                             <Select.Trigger />
                                             <Select.Content>
                                                 <Select.Item value='Private'>
-                                                    Private
+                                                    {__("Private")}
                                                 </Select.Item>
                                                 <Select.Item value='Public'>
-                                                    Public
+                                                    {__("Public")}
                                                 </Select.Item>
                                             </Select.Content>
                                         </Select.Root>
@@ -132,11 +133,11 @@ const FrappeHR = () => {
                                             />
                                         )} />
 
-                                    Show if a user is on leave
+                                    {__("Show if a user is on leave")}
                                 </Flex>
                             </Text>
                             <HelperText>
-                                If checked, users on Raven are notified if another user is on leave.
+                                {__("If checked, users on Raven are notified if another user is on leave.")}
                             </HelperText>
                         </Flex>
                     </SettingsContentContainer>

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,6 +1,7 @@
 import { SettingsSidebar } from '@/components/feature/userSettings/SettingsSidebar'
 import { PageHeader } from '@/components/layout/Heading/PageHeader'
 import { useIsDesktop } from '@/hooks/useMediaQuery'
+import { __ } from '@/utils/translations'
 import { Box, Flex, Heading } from '@radix-ui/themes'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Link } from 'react-router-dom'
@@ -15,7 +16,7 @@ const Settings = () => {
                     <Link to='/channel' className="block bg-transparent hover:bg-transparent active:bg-transparent sm:hidden">
                         <BiChevronLeft size='24' className="block text-gray-12" />
                     </Link>
-                    <Heading size='5'>Settings</Heading>
+                    <Heading size='5'>{__("Settings")}</Heading>
                 </Flex>
             </PageHeader>
             <Flex className="min-h-screen pt-16 w-full">

--- a/frontend/src/utils/translations.ts
+++ b/frontend/src/utils/translations.ts
@@ -1,0 +1,34 @@
+
+function format(message: string, replace: any) {
+    return message.replace(/{(\d+)}/g, function (match, number) {
+        return typeof replace[number] != 'undefined' ? replace[number] : match
+    })
+}
+
+function translate(message: string, replace?: any, context = null): any {
+
+    // @ts-ignore
+    const translatedMessages = window?.frappe?.boot?.__messages || {}
+
+    let translatedMessage: string = ''
+
+    if (context) {
+        let key = `${message}:${context}`
+        if (translatedMessages[key]) {
+            translatedMessage = translatedMessages[key]
+        }
+    }
+
+    if (!translatedMessage) {
+        translatedMessage = translatedMessages[message] || message
+    }
+
+    const hasPlaceholders = /{\d+}/.test(message)
+    if (!hasPlaceholders) {
+        return translatedMessage
+    }
+
+    return format(translatedMessage, replace)
+}
+
+export const __ = translate


### PR DESCRIPTION
I have added the setup & utilities for translations. 

All frontend strings need to be wrapped as `__("My String")` or with variables: `__("My String of length {0}", ["10"])`

PO files generated are only for doctype/backend related files - so we need to see how we can extend it to .tsx files. 

Will add more translatable strings gradually.

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/da0863ba-4f30-499e-818e-0921bf27c882">

Closes #356 