### PR TITLE
feat: typing indicator

### DIFF
--- a/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -62,7 +62,8 @@ type TiptapEditorProps = {
     defaultText?: string,
     replyMessage?: Message | null,
     channelMembers?: ChannelMembers,
-    channelID?: string
+    channelID?: string,
+    onUserType?: () => void,
 }
 
 export const UserMention = Mention.extend({
@@ -85,7 +86,7 @@ export const ChannelMention = Mention.extend({
         }
     })
 
-const Tiptap = ({ isEdit, slotBefore, fileProps, onMessageSend, channelMembers, channelID, replyMessage, clearReplyMessage, placeholder = 'Type a message...', messageSending, sessionStorageKey = 'tiptap-editor', disableSessionStorage = false, defaultText = '' }: TiptapEditorProps) => {
+const Tiptap = ({ isEdit, slotBefore, fileProps, onMessageSend, channelMembers, onUserType, channelID, replyMessage, clearReplyMessage, placeholder = 'Type a message...', messageSending, sessionStorageKey = 'tiptap-editor', disableSessionStorage = false, defaultText = '' }: TiptapEditorProps) => {
 
     const { enabledUsers } = useContext(UserListContext)
 
@@ -457,6 +458,9 @@ const Tiptap = ({ isEdit, slotBefore, fileProps, onMessageSend, channelMembers, 
         autofocus: 'end',
         content,
         editorProps: {
+            handleTextInput() {
+                onUserType?.()
+            },
             attributes: {
                 class: 'tiptap-editor' + (replyMessage ? ' replying' : '') + (isEdit ? ' editing-message' : '')
             }
@@ -464,7 +468,7 @@ const Tiptap = ({ isEdit, slotBefore, fileProps, onMessageSend, channelMembers, 
         onUpdate({ editor }) {
             setContent(editor.getHTML())
         }
-    }, [replyMessage])
+    }, [replyMessage, onUserType])
 
 
 

--- a/frontend/src/components/feature/chat/ChatInput/TypingIndicator/TypingIndicator.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/TypingIndicator/TypingIndicator.tsx
@@ -1,0 +1,51 @@
+import { useContext, useMemo } from 'react'
+import useTypingIndicator from './useTypingIndicator'
+import { useGetUserRecords } from '@/hooks/useGetUserRecords'
+import { UserContext } from '@/utils/auth/UserProvider'
+import { Text } from '@radix-ui/themes'
+import { HStack } from '@/components/layout/Stack'
+
+type Props = {
+    channel: string
+}
+
+const TypingIndicator = ({ channel }: Props) => {
+
+    const typingUsers = useTypingIndicator(channel)
+
+    const userRecords = useGetUserRecords()
+
+    const { currentUser } = useContext(UserContext)
+
+    const typingString = useMemo(() => {
+
+        const validTypingUsers = typingUsers.filter((user) => user !== currentUser).map((user) => userRecords[user]?.first_name ?? userRecords[user]?.full_name ?? user)
+
+        if (validTypingUsers.length === 0) return ''
+
+        if (validTypingUsers.length === 1) return validTypingUsers[0] + ' is typing...'
+
+        if (validTypingUsers.length === 2) return validTypingUsers[0] + ' and ' + validTypingUsers[1] + ' are typing...'
+
+        if (validTypingUsers.length === 3) return validTypingUsers[0] + ', ' + validTypingUsers[1] + ' and 1 other are typing...'
+
+        return validTypingUsers[0] + ', ' + validTypingUsers[1] + ' and ' + (validTypingUsers.length - 2) + ' others are typing...'
+
+
+    }, [typingUsers, userRecords, currentUser])
+
+    if (typingString === '') return null
+
+    return (
+        <HStack className='gap-1.5 pl-0.5 pt-1' align='center'>
+            <div className="flex items-center space-x-1 -mb-0.5">
+                <div className="w-1.5 h-1.5 bg-gray-12 rounded-full animate-pulse-bounce" style={{ animationDelay: '0ms' }}></div>
+                <div className="w-1.5 h-1.5 bg-gray-12 rounded-full animate-pulse-bounce" style={{ animationDelay: '150ms' }}></div>
+                <div className="w-1.5 h-1.5 bg-gray-12 rounded-full animate-pulse-bounce" style={{ animationDelay: '300ms' }}></div>
+            </div>
+            <Text size={'1'} as='span'>{typingString}</Text>
+        </HStack>
+    )
+}
+
+export default TypingIndicator

--- a/frontend/src/components/feature/chat/ChatInput/TypingIndicator/useTypingIndicator.ts
+++ b/frontend/src/components/feature/chat/ChatInput/TypingIndicator/useTypingIndicator.ts
@@ -1,0 +1,104 @@
+import { FrappeConfig, FrappeContext, useFrappeEventListener } from 'frappe-react-sdk'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
+
+
+interface TypingEventData {
+    channel: string,
+    users: string[]
+}
+
+
+const useTypingIndicator = (channel: string) => {
+    const { socket } = useContext(FrappeContext) as FrappeConfig
+    const [typingUsers, setTypingUsers] = useState<string[]>([])
+
+    useEffect(() => {
+        if (socket) {
+            socket.emit('raven_channel_get_typers', channel)
+
+            socket.io.on("reconnect", () => {
+                socket.emit('raven_channel_get_typers', channel)
+            })
+        }
+    }, [channel])
+
+    useFrappeEventListener('raven_channel_typers', (data: TypingEventData) => {
+        if (data.channel === channel) {
+            setTypingUsers(data.users)
+        }
+    })
+
+    return typingUsers
+}
+
+export const useTyping = (channel: string) => {
+
+    const [typingCounter, setTypingCounter] = useState(0)
+    const isTypingRef = useRef(false)
+
+    const { socket } = useContext(FrappeContext) as FrappeConfig
+
+    /** Function to emit typing event to the server */
+    const emitStartTyping = useCallback(() => {
+        socket?.emit('raven_channel_typing', channel)
+    }, [channel])
+
+
+    /** Function to emit typing stopped event to the server */
+    const emitStopTyping = useCallback(() => {
+        socket?.emit('raven_channel_typing_stopped', channel)
+    }, [channel])
+
+    const onUserType = useCallback(() => {
+
+        // Debounce the typing event to prevent flooding the server with events on fast typing
+        if (!isTypingRef.current) {
+            isTypingRef.current = true
+            setTypingCounter(prev => prev + 1)
+            emitStartTyping()
+        }
+
+    }, [emitStartTyping])
+
+    // Reset the typing state after a delay if the user is not typing anymore
+    // This is to prevent the typing indicator from showing indefinitely
+    // If the user does not type for more than 3 seconds, we assume that they are done typing
+    useEffect(() => {
+
+        //@ts-ignore
+        let timeout: NodeJS.Timeout
+        if (typingCounter > 0) {
+            // If the typing counter increments with every key press, we reset the timeout
+            timeout = setTimeout(() => {
+                isTypingRef.current = false
+                setTypingCounter(0)
+                emitStopTyping()
+            }, 10000)
+        }
+
+        return () => {
+            clearTimeout(timeout)
+        }
+
+    }, [typingCounter, emitStopTyping])
+
+
+    // Stop the typing indicator when the component unmounts
+    useEffect(() => {
+        return () => {
+            emitStopTyping()
+        }
+    }, [emitStopTyping])
+
+
+    const stopTyping = useCallback(() => {
+        emitStopTyping()
+        isTypingRef.current = false
+        setTypingCounter(0)
+    }, [emitStopTyping])
+
+    return { stopTyping, onUserType }
+
+}
+
+export default useTypingIndicator

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner"
 import { BiCopy, BiDotsHorizontalRounded, BiGitPullRequest, BiLinkExternal, BiPrinter, BiRightArrowAlt } from "react-icons/bi"
 import useDoctypeMeta from "@/hooks/useDoctypeMeta"
 import { HStack } from "@/components/layout/Stack"
-import { getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
+import { ErrorBanner, getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
 
 
 export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, docname: string }) => {
@@ -52,15 +52,7 @@ export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, doc
                     <Skeleton className='w-96 h-12 rounded-md' /> :
                     error ?
                         <Card>
-                            <Grid gap='2' align='center'>
-                                <Heading as='h3' size='4'>Error occurred while loading {doctype} - {docname}</Heading>
-                                <Text
-                                    size='2'
-                                    color='gray'
-                                >
-                                    {error.message}
-                                </Text>
-                            </Grid>
+                            <ErrorBanner error={error} />
                         </Card> :
                         <DoctypeCard data={data} doctype={doctype} docname={docname} copyLink={copyLink} openLink={openLink} mutate={mutate} />
             }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -143,12 +143,22 @@ export default {
       },
       animation: {
         fadein: 'fadeIn .25s ease-out',
+        'pulse-bounce': 'pulse-bounce 1.5s infinite',
       },
-
       keyframes: {
         fadeIn: {
           from: { opacity: 0 },
           to: { opacity: 1 },
+        },
+        'pulse-bounce': {
+          '0%, 100%': {
+            transform: 'translateY(0)',
+            opacity: 0.2,
+          },
+          '50%': {
+            transform: 'translateY(-1px)',
+            opacity: 0.8,
+          },
         },
       },
       transitionTimingFunction: {
@@ -187,4 +197,3 @@ export default {
     preflight: false,
   }
 }
-

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -138,6 +138,7 @@ def attach_file_to_document(doctype: str, document_id: str, file_path: str):
 
 	return {"document_id": document_id, "message": "File attached", "file_id": newFile.name}
 
+
 def get_list(doctype: str, filters: dict = None, fields: list = None, limit: int = 20):
 	"""
 	Get a list of documents from the database

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -14,9 +14,9 @@ from raven.ai.functions import (
 	delete_documents,
 	get_document,
 	get_documents,
+	get_list,
 	update_document,
 	update_documents,
-	get_list
 )
 from raven.ai.openai_client import get_open_ai_client
 
@@ -202,9 +202,9 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							function.reference_doctype,
 							filters=args.get("filters"),
 							fields=args.get("fields"),
-							limit=args.get("limit", 20)
+							limit=args.get("limit", 20),
 						)
-					
+
 					tool_outputs.append(
 						{"tool_call_id": tool.id, "output": json.dumps(function_output, default=str)}
 					)

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -1,0 +1,71 @@
+
+
+function raven_handlers(socket) {
+
+    socket.on("fire", () => {
+        socket.emit("ice");
+    });
+
+    socket.on("raven_channel_get_typers", function (channel) {
+        socket.has_permission("Raven Channel", channel).then(() => {
+            // Show who's typing in the channel - only send this to the user who requested it
+            // User emits this event when they open the channel
+            notify_typing({ socket, channel, toUser: true });
+
+        });
+    });
+
+    socket.on("raven_channel_typing", function (channel) {
+
+        // Join the typing room and notify users in the channel room that the user is typing
+        socket.join(channel_typing_room(channel));
+
+        notify_typing({ socket, channel, toUser: false });
+
+    })
+
+    socket.on("raven_channel_typing_stopped", function (channel) {
+
+
+        // Leave the typing room and notify users in the channel room that the user has stopped typing
+
+        socket.leave(channel_typing_room(channel));
+
+        notify_typing({ socket, channel, toUser: false });
+
+    })
+
+}
+
+function notify_typing(args) {
+    if (!(args && args.socket && args.channel)) return;
+
+    const socket = args.socket;
+    const channel = args.channel;
+
+    const typers_room = channel_typing_room(channel);
+
+    const clients = Array.from(socket.nsp.adapter.rooms.get(typers_room) || []);
+
+    let users = [];
+
+    socket.nsp.sockets.forEach((sock) => {
+        if (clients.includes(sock.id)) {
+            users.push(sock.user);
+        }
+    });
+
+    const channel_room = args.toUser ? user_room(args.socket.user) : open_doc_room("Raven Channel", channel);
+
+    // notify
+    socket.nsp.to(channel_room).emit("raven_channel_typers", {
+        channel,
+        users: Array.from(new Set(users)),
+    });
+}
+
+const channel_typing_room = (channel) => "raven_channel_typing:" + channel;
+const open_doc_room = (doctype, docname) => "open_doc:" + doctype + "/" + docname;
+const user_room = (user) => "user:" + user;
+
+module.exports = raven_handlers


### PR DESCRIPTION
This PR adds a typing indicator when users start typing in a channel. 

![CleanShot 2024-10-12 at 22 59 52](https://github.com/user-attachments/assets/b8a93fe7-f6a9-4f52-910c-5f98ed834f7f)

#### How it works:

1. When a user opens a channel, a socketIO event `raven_channel_get_typers` is emitted. See `useTypingIndicator.ts`
2. The socketIO handler in the backend then checks the permission for the user for that channel, and sends back a list of current active "typers" via an event `raven_channel_typers`. This event is only sent to the user who requested it - via the user room already available in Frappe.
3. When a user starts typing, a socketIO event `raven_channel_typing` is emitted by the client side. See `useTyping` in `useTypingIndicator.ts`.  To avoid multiple events being sent when the user types fast, this is throttled and only one event is sent for as long as the user types. 
4. On receiving the typing event, the handler adds the user to the "typing room" for that channel and emits the list of typers via the `raven_channel_typers` event - this time to everyone in the "channel room". 
5. When the user stops typing, we wait for 10 seconds to fire the `raven_channel_typing_stopped` event. 
6. When the user sends a message, the `raven_channel_typing_stopped` is sent immediately and the timer is reset.
7. Animations for the beat loader are added in the tailwind configuration.


So we have three rooms:
1. "user room" is the room for the specific user - available in Frappe. 
2. "Channel room" is the room for doctype "Raven Channel" and docname and - available in Frappe. 
3. "Channel typers room" - a new room housing the users who are currently typing.

> [!NOTE]  
> This will only work in version-16 (develop) branch of Frappe as of now since it's dependent on https://github.com/frappe/frappe/pull/25592



