### PR TITLE
feat: added a section for 'unread' messages in the sidebar

### DIFF
--- a/frontend/src/components/feature/channel-groups/UnreadList.tsx
+++ b/frontend/src/components/feature/channel-groups/UnreadList.tsx
@@ -1,0 +1,90 @@
+import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList } from "../../layout/Sidebar";
+import { ChannelItemElement } from '@/components/feature/channels/ChannelList';
+import { DirectMessageItemElement } from '../../feature/direct-messages/DirectMessageList';
+import { __ } from '@/utils/translations';
+import { useStickyState } from "@/hooks/useStickyState";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { SidebarBadge, SidebarViewMoreButton } from "@/components/layout/Sidebar/SidebarComp";
+import { Box, Flex } from "@radix-ui/themes";
+import { ChannelWithUnreadCount, DMChannelWithUnreadCount } from "@/components/layout/Sidebar/useGetChannelUnreadCounts";
+import clsx from "clsx";
+
+interface UnreadListProps {
+    unreadChannels: ChannelWithUnreadCount[]
+    unreadDMs: DMChannelWithUnreadCount[]
+}
+
+export const UnreadList = ({ unreadChannels, unreadDMs }: UnreadListProps) => {
+
+    const [showData, setShowData] = useStickyState(true, 'expandDirectMessageList')
+
+    const toggle = () => setShowData(d => !d)
+
+    const ref = useRef<HTMLDivElement>(null)
+
+    const [height, setHeight] = useState(ref?.current?.clientHeight ?? showData ? (unreadDMs.length + unreadChannels.length) * (36) - 4 : 0)
+
+    useLayoutEffect(() => {
+        setHeight(ref.current?.clientHeight ?? 0)
+    }, [unreadDMs, unreadChannels])
+
+    const totalUnreadCount = useMemo(() => {
+        let totalUnreadCount = 0
+
+        // Count unread messages from channels
+        for (const channel of unreadChannels) {
+            if (channel.is_archived == 0) {
+                totalUnreadCount += channel.unread_count || 0
+            }
+        }
+
+        // Count unread messages from DMs
+        for (const dm of unreadDMs) {
+            totalUnreadCount += dm.unread_count || 0
+        }
+
+        return totalUnreadCount
+    }, [unreadChannels, unreadDMs])
+
+    return (
+        <SidebarGroup>
+            <SidebarGroupItem className={'gap-1 pl-1'}>
+                <Flex width='100%' justify='between' align='center' gap='2' pr='2' className="group">
+                    <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
+                        <SidebarGroupLabel>{__("Unread")}</SidebarGroupLabel>
+                        <Box className={clsx('transition-opacity ease-in-out duration-200',
+                            !showData && totalUnreadCount > 0 ? 'opacity-100' : 'opacity-0')}>
+                            <SidebarBadge>
+                                {totalUnreadCount}
+                            </SidebarBadge>
+                        </Box>
+                    </Flex>
+                    <Flex align='center' gap='1'>
+                        <SidebarViewMoreButton onClick={toggle} expanded={showData} />
+                    </Flex>
+                </Flex>
+            </SidebarGroupItem>
+            <SidebarGroupList
+                style={{
+                    height: showData ? height : 0
+                }}>
+                <div ref={ref} className="flex gap-1 flex-col fade-in">
+                    {/* Render unread DMs */}
+                    {unreadDMs.map(dm => (
+                        <DirectMessageItemElement
+                            key={dm.name}
+                            channel={dm}
+                        />
+                    ))}
+                    {/* Render unread channels */}
+                    {unreadChannels.map(channel => (
+                        <ChannelItemElement
+                            key={channel.name}
+                            channel={channel}
+                        />
+                    ))}
+                </div>
+            </SidebarGroupList>
+        </SidebarGroup>
+    )
+}

--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -2,56 +2,37 @@ import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList, Si
 import { SidebarBadge, SidebarViewMoreButton } from "../../layout/Sidebar/SidebarComp"
 import { CreateChannelButton } from "./CreateChannelModal"
 import { useContext, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { ChannelListContext, ChannelListContextType, ChannelListItem, UnreadCountData } from "../../../utils/channel/ChannelListProvider"
+import { ChannelListContext, ChannelListContextType } from "../../../utils/channel/ChannelListProvider"
 import { ChannelIcon } from "@/utils/layout/channelIcon"
-import { Box, ContextMenu, Flex, Text } from "@radix-ui/themes"
+import { ContextMenu, Flex, Text } from "@radix-ui/themes"
 import { useLocation, useParams } from "react-router-dom"
 import { useStickyState } from "@/hooks/useStickyState"
 import useCurrentRavenUser from "@/hooks/useCurrentRavenUser"
 import { RiPushpinLine, RiUnpinLine } from "react-icons/ri"
 import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { RavenUser } from "@/types/Raven/RavenUser"
-import clsx from "clsx"
 import { __ } from "@/utils/translations"
+import { ChannelWithUnreadCount } from "@/components/layout/Sidebar/useGetChannelUnreadCounts"
 
-export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }) => {
+interface ChannelListProps {
+    channels: ChannelWithUnreadCount[]
+}
 
-    const { channels, mutate } = useContext(ChannelListContext) as ChannelListContextType
+export const ChannelList = ({ channels }: ChannelListProps) => {
 
+    const { mutate } = useContext(ChannelListContext) as ChannelListContextType
     const [showData, setShowData] = useStickyState(true, 'expandChannelList')
 
     const toggle = () => setShowData(d => !d)
 
     const { myProfile } = useCurrentRavenUser()
 
-    const { filteredChannels, totalUnreadCount } = useMemo(() => {
+    const pinnedChannelIDs = myProfile?.pinned_channels?.map(pin => pin.channel_id)
 
-        const pinnedChannelIDs = myProfile?.pinned_channels?.map(pin => pin.channel_id)
-
-        const channelList = []
-        let totalUnreadCount = 0
-
-        for (const channel of channels) {
-            if (pinnedChannelIDs?.includes(channel.name)) {
-                continue
-            }
-            if (channel.is_archived == 0) {
-                const count = unread_count?.channels.find((unread) => unread.name === channel.name)?.unread_count
-                channelList.push({
-                    ...channel,
-                    unread_count: count || 0
-                })
-
-                totalUnreadCount += count || 0
-            }
-        }
-
-
-        return {
-            filteredChannels: channelList,
-            totalUnreadCount
-        }
-    }, [channels, myProfile, unread_count])
+    // Filter channels based on pinned status
+    const filteredChannels = useMemo(() => {
+        return channels.filter(channel => !pinnedChannelIDs?.includes(channel.name))
+    }, [channels, pinnedChannelIDs])
 
     const ref = useRef<HTMLDivElement>(null)
     const [height, setHeight] = useState(ref?.current?.clientHeight ?? showData ? filteredChannels.length * (36) - 4 : 0)
@@ -66,12 +47,6 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
                 <Flex width='100%' justify='between' align='center' gap='2' pr='2' className="group">
                     <Flex align='center' gap='2' width='100%' onClick={toggle} className="cursor-default select-none">
                         <SidebarGroupLabel>{__("Channels")}</SidebarGroupLabel>
-                        <Box className={clsx('transition-opacity ease-in-out duration-200',
-                            !showData && unread_count && totalUnreadCount > 0 ? 'opacity-100' : 'opacity-0')}>
-                            <SidebarBadge>
-                                {totalUnreadCount}
-                            </SidebarBadge>
-                        </Box>
                     </Flex>
                     <Flex align='center' gap='1'>
                         <CreateChannelButton updateChannelList={mutate} />
@@ -86,7 +61,7 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
                     }}
                 >
                     <div ref={ref} className="flex gap-0.5 flex-col">
-                        {filteredChannels.map((channel) => <ChannelItem
+                        {filteredChannels.map((channel: ChannelWithUnreadCount) => <ChannelItem
                             channel={channel}
                             key={channel.name} />)}
                     </div>
@@ -96,17 +71,11 @@ export const ChannelList = ({ unread_count }: { unread_count?: UnreadCountData }
     )
 }
 
-interface ChannelListItemWithUnreadCount extends ChannelListItem {
-    unread_count: number
-}
-
-const ChannelItem = ({ channel }: { channel: ChannelListItemWithUnreadCount, }) => {
-
+const ChannelItem = ({ channel }: { channel: ChannelWithUnreadCount }) => {
     return <ChannelItemElement channel={channel} />
-
 }
 
-export const ChannelItemElement = ({ channel }: { channel: ChannelListItemWithUnreadCount }) => {
+export const ChannelItemElement = ({ channel }: { channel: ChannelWithUnreadCount }) => {
 
     const { channelID } = useParams()
 

--- a/frontend/src/components/layout/Sidebar/PinnedChannels.tsx
+++ b/frontend/src/components/layout/Sidebar/PinnedChannels.tsx
@@ -1,7 +1,7 @@
 import { ChannelListContext, ChannelListContextType, UnreadCountData } from '@/utils/channel/ChannelListProvider'
 import { useContext, useMemo } from 'react'
 import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList } from './SidebarComp'
-import { Box, Flex } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes'
 import { ChannelItemElement } from '@/components/feature/channels/ChannelList'
 import useCurrentRavenUser from '@/hooks/useCurrentRavenUser'
 import { __ } from '@/utils/translations'
@@ -18,13 +18,13 @@ const PinnedChannels = ({ unread_count }: { unread_count?: UnreadCountData }) =>
 
             return channels.filter(channel => pinnedChannelIDs?.includes(channel.name) && channel.is_archived === 0)
                 .map(channel => {
-                    const count = unread_count?.channels.find((unread) => unread.name === channel.name)?.unread_count
+                    const count = unread_count?.channels.find((unread) => unread.name === channel.name)?.unread_count || 0
                     return {
                         ...channel,
-                        unread_count: count || 0
+                        unread_count: count
                     }
-
                 })
+                .filter(channel => channel.unread_count === 0)  // Exclude channels with unread messages
         } else {
             return []
         }

--- a/frontend/src/components/layout/Sidebar/SidebarBody.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarBody.tsx
@@ -4,13 +4,23 @@ import { SidebarItem } from './SidebarComp'
 import { AccessibleIcon, Box, Flex, ScrollArea, Text } from '@radix-ui/themes'
 import useUnreadMessageCount from '@/hooks/useUnreadMessageCount'
 import PinnedChannels from './PinnedChannels'
-import React from 'react'
+import React, { useContext } from 'react'
 import { BiBookmark, BiMessageAltDetail } from 'react-icons/bi'
 import { __ } from '@/utils/translations'
+import { UnreadList } from '@/components/feature/channel-groups/UnreadList'
+import { ChannelListContext, ChannelListContextType } from '@/utils/channel/ChannelListProvider'
+import { useGetChannelUnreadCounts } from './useGetChannelUnreadCounts'
 
 export const SidebarBody = () => {
 
     const unread_count = useUnreadMessageCount()
+    const { channels, dm_channels } = useContext(ChannelListContext) as ChannelListContextType
+
+    const { unreadChannels, readChannels, unreadDMs, readDMs } = useGetChannelUnreadCounts({
+        channels,
+        dm_channels,
+        unread_count: unread_count?.message
+    })
 
     return (
         <ScrollArea type="hover" scrollbars="vertical" className='h-[calc(100vh-7rem)]'>
@@ -28,8 +38,9 @@ export const SidebarBody = () => {
                         iconLabel='Saved Message' />
                     <PinnedChannels unread_count={unread_count?.message} />
                 </Flex>
-                <ChannelList unread_count={unread_count?.message} />
-                <DirectMessageList unread_count={unread_count?.message} />
+                {(unreadChannels.length > 0 || unreadDMs.length > 0) && <UnreadList unreadChannels={unreadChannels} unreadDMs={unreadDMs} />}
+                <ChannelList channels={readChannels} />
+                <DirectMessageList dm_channels={readDMs} />
             </Flex>
         </ScrollArea>
     )

--- a/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
+++ b/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
@@ -1,0 +1,61 @@
+import { ChannelListItem, DMChannelListItem, UnreadCountData } from '@/utils/channel/ChannelListProvider';
+import { useMemo } from 'react';
+
+export interface UseGetChannelUnreadCountProps {
+    channels: ChannelListItem[]
+    dm_channels: DMChannelListItem[]
+    unread_count: UnreadCountData | undefined
+}
+
+export interface ChannelWithUnreadCount extends ChannelListItem {
+    unread_count: number
+}
+
+export interface DMChannelWithUnreadCount extends DMChannelListItem {
+    unread_count: number
+}
+
+export const useGetChannelUnreadCounts = ({ channels, dm_channels, unread_count }: UseGetChannelUnreadCountProps) => {
+
+    const { unreadChannels, readChannels, unreadDMs, readDMs } = useMemo(() => {
+
+        const unreadCounts: Record<string, number> = {}
+
+        // Create a mapping of channel names to unread counts
+        unread_count?.channels?.forEach(item => {
+            unreadCounts[item.name] = item.unread_count || 0
+        })
+
+        const unreadChannels: ChannelWithUnreadCount[] = []
+        const readChannels: ChannelWithUnreadCount[] = []
+        const unreadDMs: DMChannelWithUnreadCount[] = []
+        const readDMs: DMChannelWithUnreadCount[] = []
+
+        const allChannels: (ChannelListItem | DMChannelListItem)[] = [...channels, ...dm_channels]
+
+        // Process all channels and DMs to separate unread and read
+        allChannels.forEach(channel => {
+            const unreadCount = unreadCounts[channel.name] || 0
+            const channelWithUnread = { ...channel, unread_count: unreadCount }
+
+            if (unreadCount > 0) {
+                if ('is_direct_message' in channel && channel.is_direct_message) {
+                    unreadDMs.push(channelWithUnread as DMChannelWithUnreadCount)
+                } else {
+                    unreadChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                }
+            } else {
+                if ('is_direct_message' in channel && channel.is_direct_message) {
+                    readDMs.push(channelWithUnread as DMChannelWithUnreadCount)
+                } else {
+                    readChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                }
+            }
+        });
+
+        return { unreadChannels, readChannels, unreadDMs, readDMs }
+
+    }, [channels, dm_channels, unread_count])
+
+    return { unreadChannels, readChannels, unreadDMs, readDMs }
+}

--- a/raven/api/raven_channel.py
+++ b/raven/api/raven_channel.py
@@ -205,6 +205,6 @@ def mark_all_messages_as_read(channel_ids: list):
 	"""    
 	user = frappe.session.user
 	for channel_id in channel_ids:
-		track_channel_visit(channel_id, user=user, publish_event_for_user=True)
+		track_channel_visit(channel_id, user=user)
 
 	return "Ok"

--- a/raven/api/raven_channel.py
+++ b/raven/api/raven_channel.py
@@ -3,6 +3,7 @@ from frappe import _
 from frappe.query_builder import Order
 
 from raven.api.raven_users import get_current_raven_user
+from raven.utils import track_channel_visit
 
 
 @frappe.whitelist()
@@ -193,5 +194,17 @@ def leave_channel(channel_id):
 
 	for member in members:
 		frappe.delete_doc("Raven Channel Member", member.name)
+
+	return "Ok"
+
+
+@frappe.whitelist()
+def mark_all_messages_as_read(channel_ids: list):
+	"""
+	Mark all messages in these channels as read
+	"""    
+	user = frappe.session.user
+	for channel_id in channel_ids:
+		track_channel_visit(channel_id, user=user, publish_event_for_user=True)
 
 	return "Ok"


### PR DESCRIPTION
1. Create a new `UnreadList` component that displays channels and DMs with unread messages.
2. Filter out unread items from the existing `ChannelList` and `DirectMessageList` components to avoid duplicates.
3. Do not show the `UnreadList` section when there are no unread messages.

<img width="1512" alt="Screenshot 2024-10-13 at 3 53 09 PM" src="https://github.com/user-attachments/assets/cca900ce-4e39-4c04-8ac7-9fa266c56ca9">
<img width="1512" alt="Screenshot 2024-10-13 at 3 53 18 PM" src="https://github.com/user-attachments/assets/6e902410-5443-4a47-9d0f-3132b730ea41">
<img width="1512" alt="Screenshot 2024-10-13 at 3 53 28 PM" src="https://github.com/user-attachments/assets/efe4ce17-efec-4d92-a8d6-91f73adc709b">

