### PR TITLE
fix: create Raven User for administrator on install

### DIFF
--- a/raven/install.py
+++ b/raven/install.py
@@ -1,10 +1,13 @@
 import click
-from frappe.desk.page.setup_wizard.setup_wizard import make_records
+import frappe
+from frappe.desk.page.setup_wizard.setup_wizard import add_all_roles_to, make_records
 
 
 def after_install():
 	try:
 		print("Setting up Raven...")
+		add_all_roles_to("Administrator")
+		create_raven_user_for_administrator()
 		create_general_channel()
 
 		click.secho("Thank you for installing Raven!", fg="green")
@@ -18,6 +21,19 @@ def after_install():
 			fg="bright_red",
 		)
 		raise e
+
+
+def create_raven_user_for_administrator():
+
+	if not frappe.db.exists("Raven User", {"user": "Administrator"}):
+		frappe.get_doc(
+			{
+				"doctype": "Raven User",
+				"user": "Administrator",
+				"full_name": "Administrator",
+				"type": "User",
+			}
+		).insert(ignore_permissions=True)
 
 
 def create_general_channel():

--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -139,17 +139,8 @@ def add_user_to_raven(doc, method):
 				if doc.user_type == "System User":
 					auto_add = frappe.db.get_single_value("Raven Settings", "auto_add_system_users")
 
-					if auto_add:
+					if auto_add or "Raven User" in [d.role for d in doc.get("roles")]:
 						doc.append("roles", {"role": "Raven User"})
-						# Create a Raven User record for the user.
-						raven_user = frappe.new_doc("Raven User")
-						raven_user.user = doc.name
-						if not doc.full_name:
-							raven_user.full_name = doc.first_name
-						raven_user.enabled = doc.enabled
-						raven_user.insert(ignore_permissions=True)
-				else:
-					if "Raven User" in [d.role for d in doc.get("roles")]:
 						# Create a Raven User record for the user.
 						raven_user = frappe.new_doc("Raven User")
 						raven_user.user = doc.name

--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
@@ -84,7 +84,7 @@ class RavenChannel(Document):
 		If it is created by a bot, we will add the bot as a member.
 		"""
 		# add current user as channel member
-		if not frappe.flags.in_test:
+		if not frappe.flags.in_test and not frappe.flags.in_install:
 
 			if self.is_direct_message == 1:
 				# Add both users as members


### PR DESCRIPTION
On install, add all roles to Administrator and create a Raven User for it. Do not create a channel member for the administrator. 

Closes #1130 