### PR TITLE
fix: AI bot handler uses user_id to fetch bot doc

### DIFF
--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -174,7 +174,7 @@ class RavenMessage(Document):
 			return
 
 		# Get the bot user doc
-		peer_user_doc = frappe.get_cached_doc("Raven User", peer_user)
+		peer_user_doc = frappe.get_cached_doc("Raven User", peer_user.get("user_id"))
 
 		if peer_user_doc.type != "Bot" or not peer_user_doc.bot:
 			return


### PR DESCRIPTION
Closes #1186

Bug introduced because of caching channel members
