### PR TITLE
fix(web): send document links with doctype preview

### DIFF
--- a/raven/api/document_link.py
+++ b/raven/api/document_link.py
@@ -73,6 +73,7 @@ def get_preview_data(doctype, docname):
 		"preview_image": preview_data.get(image_field),
 		"preview_title": preview_data.get(title_field),
 		"id": preview_data.get("name"),
+		"raven_document_link": get(doctype, docname),
 	}
 
 	for key, val in preview_data.items():


### PR DESCRIPTION
Instead of fetching the document link on clicking the copy/open link button, we now send it with the doctype preview itself. This should fix #1193 