### PR TITLE
feat: add emoji-mart for emoji picker

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "copy-html-entry": "cp ../raven/public/raven/index.html ../raven/www/raven.html"
   },
   "dependencies": {
+    "@emoji-mart/react": "^1.1.1",
     "@radix-ui/themes": "3.1.4",
     "@tiptap/extension-code-block-lowlight": "2.5.9",
     "@tiptap/extension-highlight": "2.5.9",
@@ -37,7 +38,7 @@
     "cva": "npm:class-variance-authority",
     "dayjs": "^1.11.11",
     "downshift": "^8.3.1",
-    "emoji-picker-element": "^1.25.0",
+    "emoji-mart": "^5.6.0",
     "firebase": "^10.9.0",
     "frappe-react-sdk": "^1.9.0",
     "highlight.js": "^11.9.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Cookies from 'js-cookie'
 import ErrorPage from './pages/ErrorPage'
 import WorkspaceSwitcher from './pages/WorkspaceSwitcher'
 import WorkspaceSwitcherGrid from './components/layout/WorkspaceSwitcherGrid'
+import { init } from 'emoji-mart'
 
 /** Following keys will not be cached in app cache */
 const NO_CACHE_KEYS = [
@@ -28,6 +29,19 @@ const isDesktop = window.innerWidth > 768
 
 const lastWorkspace = localStorage.getItem('ravenLastWorkspace') ?? ''
 const lastChannel = localStorage.getItem('ravenLastChannel') ?? ''
+
+
+// Initialize emoji-mart
+init({
+  data: async () => {
+    const response = await fetch(
+      'https://cdn.jsdelivr.net/npm/@emoji-mart/data/sets/14/apple.json',
+    )
+
+    return response.json()
+  },
+  set: 'apple',
+})
 
 
 const router = createBrowserRouter(

--- a/frontend/src/components/common/EmojiPicker/EmojiPicker.tsx
+++ b/frontend/src/components/common/EmojiPicker/EmojiPicker.tsx
@@ -1,34 +1,23 @@
-import { createElement, useEffect, useRef } from "react"
-import 'emoji-picker-element'
-import './emojiPicker.styles.css'
 import { useTheme } from "@/ThemeProvider"
-import { Database } from "emoji-picker-element";
-
-export const emojiDatabase = new Database();
+import Picker from '@emoji-mart/react'
 
 const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
-
-    const ref = useRef<any>(null)
     const { appearance } = useTheme()
 
-    useEffect(() => {
-        const handler = (event: any) => {
-            emojiDatabase.incrementFavoriteEmojiCount(event.detail.unicode)
-            onSelect(event.detail.unicode)
-        }
-        ref.current?.addEventListener('emoji-click', handler)
-        ref.current.skinToneEmoji = '👍'
+    const onEmojiSelect = (emoji: any) => {
+        onSelect(emoji.native)
+    }
 
-        const style = document.createElement('style');
-        style.textContent = `.picker { border-radius: var(--radius-4); box-shadow: var(--shadow-6); } input.search{ color: ${appearance === 'light' ? '#020617' : '#f1f5f9'} }`
-        ref.current.shadowRoot.appendChild(style);
+    return <Picker
+        maxFrequentRows={2}
+        set='apple'
+        onEmojiSelect={onEmojiSelect}
+        skinTonePosition='search'
+        theme={appearance === 'inherit' ? 'auto' : appearance}
+        autoFocus={true}
+    />
 
-        return () => {
-            ref.current?.removeEventListener('emoji-click', handler)
-        }
-    }, [])
 
-    return createElement('emoji-picker', { ref })
 }
 
 export default EmojiPicker

--- a/frontend/src/components/feature/chat/ChatInput/ChannelMentionList.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/ChannelMentionList.tsx
@@ -60,7 +60,7 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
             <Flex
                 direction='column'
                 gap='0'
-                className='shadow-lg dark:backdrop-blur-[32px] dark:bg-panel-translucent bg-white overflow-y-scroll max-h-64 rounded-md'
+                className='shadow-lg dark:bg-panel-solid bg-white overflow-y-scroll max-h-64 rounded-md'
             >
                 {props?.items.length
                     ? props.items.map((item: ChannelListItem, index: number) => (

--- a/frontend/src/components/feature/chat/ChatInput/EmojiList.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/EmojiList.tsx
@@ -1,12 +1,12 @@
 import { Flex, Text, Theme } from '@radix-ui/themes'
 import { ReactRendererOptions } from '@tiptap/react'
 import { clsx } from 'clsx'
-import { NativeEmoji } from 'emoji-picker-element/shared'
 import {
     forwardRef, useEffect, useImperativeHandle,
     useRef,
     useState,
 } from 'react'
+import { EmojiType } from './EmojiSuggestion'
 
 export default forwardRef((props: ReactRendererOptions['props'], ref) => {
 
@@ -60,16 +60,16 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
             <Flex
                 direction='column'
                 gap='0'
-                className='shadow-lg dark:backdrop-blur-[8px] dark:bg-panel-translucent bg-white overflow-y-scroll max-h-96 rounded-md'
+                className='shadow-lg dark:bg-panel-solid bg-white overflow-y-scroll max-h-96 rounded-md'
             >
                 {props?.items.length
-                    ? props.items.map((item: NativeEmoji, index: number) => (
+                    ? props.items.map((item: EmojiType, index: number) => (
                         <MentionItem
                             item={item}
                             index={index}
                             selectItem={selectItem}
                             selectedIndex={selectedIndex}
-                            key={item.annotation}
+                            key={item.shortcodes ?? item.id}
                             itemsLength={props.items.length}
                         />
                     ))
@@ -80,7 +80,7 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
     )
 })
 
-const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: NativeEmoji, selectItem: (index: number) => void }) => {
+const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: EmojiType, selectItem: (index: number) => void }) => {
 
     const ref = useRef<HTMLDivElement>(null)
 
@@ -93,9 +93,9 @@ const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { 
         role='button'
         ref={ref}
         align='center'
-        title={item.annotation}
-        aria-label={`Select emoji ${item.annotation}`}
-        className={clsx('px-3 py-1.5 gap-2 rounded-md',
+        title={item.id}
+        aria-label={`Select emoji ${item.id}`}
+        className={clsx('px-3 py-1.5 gap-2 rounded-md cursor-pointer',
             index === itemsLength - 1 ? 'rounded-b-md' : 'rounded-b-none',
             index === 0 ? 'rounded-t-md' : 'rounded-t-none',
             index === selectedIndex ? 'bg-accent-a5' : 'bg-panel-translucent'
@@ -103,6 +103,9 @@ const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { 
         key={index}
         onClick={() => selectItem(index)}
     >
-        <Text as='span' weight='medium' size='2'>{item.unicode} {item.shortcodes?.[0] ?? item.annotation}</Text>
+
+        <Text as='span' weight='medium' size='2'>
+            {/* @ts-expect-error */}
+            <em-emoji shortcodes={item.shortcodes}></em-emoji> {item.shortcodes ?? item.id}</Text>
     </Flex >
 }

--- a/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
@@ -3,9 +3,53 @@ import Suggestion from '@tiptap/suggestion'
 import { ReactRenderer } from '@tiptap/react'
 import EmojiList from './EmojiList'
 import tippy from 'tippy.js';
-import { NativeEmoji } from 'emoji-picker-element/shared';
 import { PluginKey } from '@tiptap/pm/state';
-import { emojiDatabase } from '@/components/common/EmojiPicker/EmojiPicker';
+import { SearchIndex, FrequentlyUsed } from 'emoji-mart';
+
+export type EmojiType = {
+    shortcodes?: string,
+    emoji?: string,
+    name?: string,
+    id: string,
+}
+
+async function search(value: string, maxResults: number = 10): Promise<EmojiType[]> {
+    const emojis = await SearchIndex.search(value, { maxResults: maxResults, caller: undefined })
+    const results = emojis.map((emoji: any) => {
+        return {
+            shortcodes: emoji.skins[0].shortcodes,
+            emoji: emoji.skins[0].native,
+            name: emoji.name,
+            id: emoji.id,
+        }
+    })
+
+    return results
+}
+
+function getTopFavoriteEmojis(maxResults: number = 10): EmojiType[] {
+
+    // ID's of emojis
+
+    // @ts-expect-error
+    const emojis = FrequentlyUsed.get({ maxFrequentRows: 1, perLine: maxResults })
+
+    const results: EmojiType[] = emojis.map((emoji: string) => {
+
+        // @ts-expect-error
+        const e = SearchIndex.get(emoji)
+
+        return {
+            id: e.id,
+            shortcodes: e.skins[0].shortcodes,
+            emoji: e.skins[0].native,
+            name: e.name,
+        }
+    })
+
+    return results
+}
+
 
 export const EmojiSuggestion = Node.create({
     name: 'emoji',
@@ -25,15 +69,10 @@ export const EmojiSuggestion = Node.create({
                 char: ':',
                 items: (query) => {
                     if (query.query.length !== 0) {
-                        return emojiDatabase.getEmojiBySearchQuery(query.query.toLowerCase()).then((emojis) => {
-                            return emojis.slice(0, 10) as NativeEmoji[]
-                        });
+                        return search(query.query)
                     } else {
-                        return emojiDatabase.getTopFavoriteEmoji(10) as Promise<NativeEmoji[]>
+                        return getTopFavoriteEmojis()
                     }
-
-
-                    return []
                 },
                 render: () => {
                     let component: any;
@@ -91,9 +130,11 @@ export const EmojiSuggestion = Node.create({
                 },
                 command: ({ editor, range, props }) => {
                     // Replace the text from : to with the emoji node
-                    editor.chain().focus().deleteRange(range).insertContent(props.unicode).run()
+                    editor.chain().focus().deleteRange(range).insertContent(props.emoji).run()
 
-                    emojiDatabase.incrementFavoriteEmojiCount(props.unicode)
+                    FrequentlyUsed.add(props.id)
+
+                    // emojiDatabase.incrementFavoriteEmojiCount(props.unicode)
 
                     window.getSelection()?.collapseToEnd()
                 },

--- a/frontend/src/components/feature/chat/ChatInput/MentionList.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/MentionList.tsx
@@ -62,7 +62,7 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
             <Flex
                 direction='column'
                 gap='0'
-                className='shadow-lg dark:backdrop-blur-[32px] dark:bg-panel-translucent bg-white overflow-y-scroll max-h-96 rounded-md'
+                className='shadow-lg dark:bg-panel-solid bg-white overflow-y-scroll max-h-96 rounded-md'
             >
                 {props?.items.length
                     ? props.items.map((item: UserFields, index: number) => (

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
@@ -1,19 +1,22 @@
 import { lazy, Suspense } from 'react'
-import { Box, Flex, IconButton, Popover, Portal, Tooltip } from '@radix-ui/themes'
+import { Box, Flex, IconButton, IconButtonProps, Popover, Portal, Tooltip } from '@radix-ui/themes'
 import { DIALOG_CONTENT_CLASS } from '@/utils/layout/dialog'
 import { Loader } from '@/components/common/Loader'
 import { QUICK_ACTION_BUTTON_CLASS } from './QuickActionButton'
 import { LuSmilePlus } from 'react-icons/lu'
+import clsx from 'clsx'
 
 const EmojiPicker = lazy(() => import('@/components/common/EmojiPicker/EmojiPicker'))
 
 interface EmojiPickerButtonProps {
     saveReaction: (emoji: string) => void,
     isOpen: boolean
-    setIsOpen: (open: boolean) => void
+    setIsOpen: (open: boolean) => void,
+    iconButtonProps?: IconButtonProps,
+    iconSize?: string
 }
 
-export const EmojiPickerButton = ({ saveReaction, isOpen, setIsOpen }: EmojiPickerButtonProps) => {
+export const EmojiPickerButton = ({ saveReaction, isOpen, setIsOpen, iconButtonProps, iconSize = '18' }: EmojiPickerButtonProps) => {
 
     const onClose = () => {
         setIsOpen(false)
@@ -27,15 +30,16 @@ export const EmojiPickerButton = ({ saveReaction, isOpen, setIsOpen }: EmojiPick
     return (
         <Popover.Root open={isOpen} onOpenChange={setIsOpen}>
             <Flex>
-                <Tooltip content='find another reaction'>
+                <Tooltip content='Add reaction'>
                     <Popover.Trigger>
                         <IconButton
                             variant='soft'
                             size='2'
-                            className={QUICK_ACTION_BUTTON_CLASS}
                             color='gray'
-                            aria-label='pick emoji'>
-                            <LuSmilePlus size='18' />
+                            aria-label='pick emoji'
+                            {...iconButtonProps}
+                            className={clsx(QUICK_ACTION_BUTTON_CLASS, iconButtonProps?.className)}>
+                            <LuSmilePlus size={iconSize} />
                         </IconButton>
                     </Popover.Trigger>
                 </Tooltip>

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
@@ -1,9 +1,9 @@
 import { lazy, Suspense } from 'react'
 import { Box, Flex, IconButton, Popover, Portal, Tooltip } from '@radix-ui/themes'
 import { DIALOG_CONTENT_CLASS } from '@/utils/layout/dialog'
-import { BiSmile } from 'react-icons/bi'
 import { Loader } from '@/components/common/Loader'
 import { QUICK_ACTION_BUTTON_CLASS } from './QuickActionButton'
+import { LuSmilePlus } from 'react-icons/lu'
 
 const EmojiPicker = lazy(() => import('@/components/common/EmojiPicker/EmojiPicker'))
 
@@ -35,7 +35,7 @@ export const EmojiPickerButton = ({ saveReaction, isOpen, setIsOpen }: EmojiPick
                             className={QUICK_ACTION_BUTTON_CLASS}
                             color='gray'
                             aria-label='pick emoji'>
-                            <BiSmile size='18' />
+                            <LuSmilePlus size='18' />
                         </IconButton>
                     </Popover.Trigger>
                 </Tooltip>

--- a/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
@@ -1,10 +1,11 @@
 import { useFrappePostCall } from "frappe-react-sdk"
-import { useCallback, useContext, useMemo } from "react"
+import { useCallback, useContext, useMemo, useState } from "react"
 import { UserContext } from "../../../../utils/auth/UserProvider"
 import { getUsers } from "../../../../utils/operations"
 import { useGetUserRecords } from "@/hooks/useGetUserRecords"
 import { Flex, IconButton, Text, Tooltip } from "@radix-ui/themes"
 import { clsx } from "clsx"
+import { EmojiPickerButton } from "./MessageActions/QuickActions/EmojiPickerButton"
 
 export interface ReactionObject {
     // The emoji
@@ -36,6 +37,8 @@ export const MessageReactions = ({ messageID, message_reactions }: { messageID: 
         return Object.values(parsed_json)
     }, [message_reactions])
 
+    if (reactions.length === 0) return null
+
     return (
         <Flex gap='1' mt='1' wrap='wrap'>
             {reactions.map((reaction) => {
@@ -49,8 +52,29 @@ export const MessageReactions = ({ messageID, message_reactions }: { messageID: 
                     />
                 )
             })}
+            <AddReactionButton
+                saveReaction={saveReaction}
+            />
         </Flex>
     )
+}
+
+const AddReactionButton = ({ saveReaction }: { saveReaction: (emoji: string) => void }) => {
+
+    const [isOpen, setIsOpen] = useState(false)
+
+    return <EmojiPickerButton
+        saveReaction={saveReaction}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        iconButtonProps={{
+            size: '1',
+            className: 'bg-gray-3 dark:bg-gray-5 py-0.5 w-[3ch] text-gray-10 dark:text-gray-11 h-full rounded-md',
+            variant: 'soft',
+            color: 'gray'
+        }}
+        iconSize='15'
+    />
 }
 
 interface ReactionButtonProps {

--- a/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
@@ -77,16 +77,15 @@ const ReactionButton = ({ reaction, onReactionClick, currentUser, allUsers }: Re
         <Tooltip content={<p className="my-0 max-w-96">
             {label}
         </p>}>
-            <IconButton
-                size='1'
+            <button
                 onClick={onClick}
-                radius='large'
-                className={clsx("w-fit sm:h-full text-xs py-0.5 cursor-pointer sm:hover:bg-white sm:dark:hover:bg-gray-10",
-                    currentUserReacted ? "bg-accent-4 dark:bg-gray-7 font-bold" : "bg-gray-3 dark:bg-gray-4")}>
-                <Text as='span' className={clsx("w-fit px-2 text-gray-12")}>
-                    {emoji} {count}
+                className={clsx("w-fit sm:h-full text-xs py-0.5 cursor-pointer rounded-md min-w-[5ch] border font-semibold",
+                    currentUserReacted ? "bg-blue-50 border-blue-500 dark:border-gray-9 dark:bg-gray-7 sm:dark:hover:bg-gray-7" : "bg-gray-3 border-gray-3 sm:hover:bg-gray-2 sm:hover:border-gray-8 dark:bg-gray-5 sm:dark:hover:bg-gray-5 sm:dark:hover:border-gray-9")}>
+                <Text as='span' className={clsx("block min-w-[3.5ch] tabular-nums text-gray-12", currentUserReacted ? "text-blue-800 dark:text-gray-12" : "text-gray-12")}>
+                    {/* @ts-expect-error */}
+                    <em-emoji native={emoji}></em-emoji> {count}
                 </Text>
-            </IconButton>
+            </button>
         </Tooltip>
     )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -974,6 +974,11 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
+"@emoji-mart/react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emoji-mart/react/-/react-1.1.1.tgz#ddad52f93a25baf31c5383c3e7e4c6e05554312a"
+  integrity sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
@@ -1674,6 +1679,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
   integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
 
+"@radix-ui/primitive@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
+  integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
 "@radix-ui/react-accessible-icon@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.0.tgz#2ae1f2b21842cc3ed4b829203b557951112b7c91"
@@ -1746,6 +1756,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
 
+"@radix-ui/react-compose-refs@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
+  integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
+
 "@radix-ui/react-context-menu@2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context-menu/-/react-context-menu-2.2.1.tgz#a2c7812336a40cd22900c888336ad6e1adc6a1bc"
@@ -1763,7 +1778,12 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
   integrity sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==
 
-"@radix-ui/react-dialog@1.1.1", "@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.2":
+"@radix-ui/react-context@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
+  integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-dialog@1.1.1", "@radix-ui/react-dialog@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz#4906507f7b4ad31e22d7dad69d9330c87c431d44"
   integrity sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==
@@ -1783,6 +1803,26 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.7"
 
+"@radix-ui/react-dialog@^1.1.2":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz#d68e977acfcc0d044b9dab47b6dd2c179d2b3191"
+  integrity sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.3"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.1"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-portal" "1.1.3"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.6.1"
+
 "@radix-ui/react-direction@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.1.0.tgz#a7d39855f4d077adc2a1922f9c353c5977a09cdc"
@@ -1796,6 +1836,17 @@
     "@radix-ui/primitive" "1.1.0"
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
+"@radix-ui/react-dismissable-layer@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz#4ee0f0f82d53bf5bd9db21665799bb0d1bad5ed8"
+  integrity sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
@@ -1817,6 +1868,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz#8e9abb472a9a394f59a1b45f3dd26cfe3fc6da13"
   integrity sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==
 
+"@radix-ui/react-focus-guards@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz#8635edd346304f8b42cae86b05912b61aef27afe"
+  integrity sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==
+
 "@radix-ui/react-focus-scope@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz#ebe2891a298e0a33ad34daab2aad8dea31caf0b2"
@@ -1824,6 +1880,15 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-focus-scope@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz#5c602115d1db1c4fcfa0fae4c3b09bb8919853cb"
+  integrity sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
 "@radix-ui/react-form@0.1.0":
@@ -1956,6 +2021,14 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-portal@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.3.tgz#b0ea5141103a1671b715481b13440763d2ac4440"
+  integrity sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.0.tgz#227d84d20ca6bfe7da97104b1a8b48a833bfb478"
@@ -1964,12 +2037,27 @@
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-presence@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.2.tgz#bb764ed8a9118b7ec4512da5ece306ded8703cdc"
+  integrity sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-primitive@2.0.0", "@radix-ui/react-primitive@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz#fe05715faa9203a223ccc0be15dc44b9f9822884"
   integrity sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
+
+"@radix-ui/react-primitive@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz#6d9efc550f7520135366f333d1e820cf225fad9e"
+  integrity sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.1"
 
 "@radix-ui/react-progress@1.1.0":
   version "1.1.0"
@@ -2075,6 +2163,13 @@
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-slot@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.1.tgz#ab9a0ffae4027db7dc2af503c223c978706affc3"
+  integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
 
 "@radix-ui/react-switch@1.1.0":
   version "1.1.0"
@@ -3363,10 +3458,10 @@ electron-to-chromium@^1.5.4:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz#1abf0410c5344b2b829b7247e031f02810d442e6"
   integrity sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==
 
-emoji-picker-element@^1.25.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/emoji-picker-element/-/emoji-picker-element-1.25.0.tgz#d052528b6bf0d41aaf3d35a937329a482ac040e0"
-  integrity sha512-UcUMxqIuneLCsEJ5KpqTD1xaHZyUpg6Oa7uCVe5AMXXpsW3C2TNegbNLXj2/rlbyr6qVMf7lXTFyzvFEarOIUg==
+emoji-mart@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-5.6.0.tgz#71b3ed0091d3e8c68487b240d9d6d9a73c27f023"
+  integrity sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -4927,6 +5022,14 @@ react-remove-scroll-bar@^2.3.4:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
 react-remove-scroll@2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz#15a1fd038e8497f65a695bf26a4a57970cac1ccb"
@@ -4936,6 +5039,17 @@ react-remove-scroll@2.5.7:
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-remove-scroll@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz#2518d2c5112e71ea8928f1082a58459b5c7a2a97"
+  integrity sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
 react-router-dom@^6.26.1:
@@ -4960,6 +5074,14 @@ react-style-singleton@^2.2.1:
   dependencies:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-style-singleton@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
     tslib "^2.0.0"
 
 react-virtuoso@^4.12.3:
@@ -5682,6 +5804,13 @@ use-callback-ref@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
   integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==
+  dependencies:
+    tslib "^2.0.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
Replace emoji-picker-element with emoji-mart

Why?

1. Emojis will be rendered consistently across operating systems. Windows emojis are weird, hence this will use Apple's emoji palette for all operating systems.
2. Will allow us to add custom emojis to the main palette. 

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/827ae6d5-445a-456c-9614-9462fd8d3c14" />
