### PR TITLE
feat: configure document previews

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,7 @@ const router = createBrowserRouter(
             <Route path="users" lazy={() => import('./pages/settings/Users/UserList')} />
             <Route path="appearance" lazy={() => import('./pages/settings/Appearance')} />
             <Route path="hr" lazy={() => import('./pages/settings/Integrations/FrappeHR')} />
-
+            <Route path="document-previews" lazy={() => import('./pages/settings/Integrations/DocumentPreviewTool')} />
             <Route path="workspaces" >
               <Route index lazy={() => import('./pages/settings/Workspaces/WorkspaceList')} />
               <Route path=":ID" lazy={() => import('./pages/settings/Workspaces/ViewWorkspace')} />

--- a/frontend/src/components/feature/DocumentPreviewToolConfigurator.tsx
+++ b/frontend/src/components/feature/DocumentPreviewToolConfigurator.tsx
@@ -1,0 +1,172 @@
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { HStack, Stack } from '../layout/Stack'
+import { Badge, Button, CheckboxCards, Grid, Heading, ScrollArea, Spinner, Text, TextField } from '@radix-ui/themes'
+import LinkField from '../common/LinkField/LinkField'
+import { DoctypeLinkRenderer } from './chat/ChatMessage/Renderers/DoctypeLinkRenderer'
+import { FrappeConfig, FrappeContext, useFrappePostCall, useSWRConfig } from 'frappe-react-sdk'
+import useDoctypeMeta from '@/hooks/useDoctypeMeta'
+import { DocField } from '@/types/Core/DocField'
+import { BiSearch } from 'react-icons/bi'
+import { toast } from 'sonner'
+import { ErrorBanner, getErrorMessage } from '../layout/AlertBanner/ErrorBanner'
+
+type Props = {}
+
+const DocumentPreviewToolConfigurator = (props: Props) => {
+
+    const [doctype, setDoctype] = useState('')
+    const [docname, setDocname] = useState('')
+
+    return (
+        <Grid columns='2' gap='4'>
+            <Stack>
+                <Heading size='3' className='not-cal'>Configure</Heading>
+                <LinkField
+                    label='Select a DocType'
+                    doctype={"DocType"}
+                    filters={[
+                        ['issingle', '=', 0],
+                        ['istable', '=', 0]
+                    ]}
+                    value={doctype}
+                    setValue={setDoctype}
+                />
+                {doctype && <DocTypePreviewFields doctype={doctype} docname={docname} />}
+            </Stack>
+
+            {doctype && <DocTypePreview doctype={doctype} docname={docname} setDocname={setDocname} />}
+        </Grid>
+
+    )
+}
+
+const NO_VALUE_FIELDS = ["Section Break",
+    "Column Break",
+    "Tab Break",
+    "HTML",
+    "Table",
+    "Table MultiSelect",
+    "Button",
+    "Image",
+    "Fold",
+    "Heading",
+    "Table", "Table MultiSelect"]
+
+const DocTypePreviewFields = ({ doctype, docname }: { doctype: string, docname: string }) => {
+
+    const { doc, mutate: mutateMeta } = useDoctypeMeta(doctype)
+
+
+    const { previewFields, eligibleFields } = useMemo(() => {
+
+        const eligibleFields = doc?.fields?.filter(field => !NO_VALUE_FIELDS.includes(field.fieldtype) && field.fieldname) ?? []
+        // All fields that are in preview and not in NO_VALUE_FIELDS
+        const previewFields = eligibleFields?.filter(field => field.in_preview) ?? []
+        return { previewFields, eligibleFields }
+    }, [doc])
+
+    if (!doc) return null
+
+    return <DocTypePreviewEditor doctype={doctype} docname={docname} eligibleFields={eligibleFields} previewFields={previewFields} mutateMeta={mutateMeta} />
+
+}
+
+const DocTypePreviewEditor = ({ doctype, docname, eligibleFields, previewFields, mutateMeta }: { doctype: string, docname: string, eligibleFields: DocField[], previewFields: DocField[], mutateMeta: () => void }) => {
+    const [search, setSearch] = useState("")
+
+    const filteredFields = useMemo(() => {
+        const searchTerm = search.toLowerCase()
+        return eligibleFields.filter(field => field.fieldname?.toLowerCase().includes(searchTerm))
+    }, [eligibleFields, search])
+
+    const [selectedFields, setSelectedFields] = useState<string[]>(previewFields.map(field => field.fieldname ?? ''))
+
+    const [hasChanged, setHasChanged] = useState(false)
+
+    const onFieldChange = (fields: string[]) => {
+        setSelectedFields(fields)
+        setHasChanged(true)
+    }
+
+    const { mutate } = useSWRConfig()
+
+    const { call, loading, error } = useFrappePostCall('raven.api.document_link.update_preview_fields')
+
+    const handleUpdate = () => {
+        call({ doctype, fields: selectedFields })
+            .then(() => {
+                toast.success('Fields updated')
+                setHasChanged(false)
+                mutateMeta()
+                mutate(`raven.api.document_link.get_preview_data?doctype=${encodeURIComponent(doctype)}&docname=${encodeURIComponent(docname)}`)
+            })
+            .catch(error => {
+                toast.error(getErrorMessage(error))
+            })
+    }
+
+    console.log(previewFields)
+
+
+    return <Stack>
+        {previewFields.length === 0 && <div>
+            <Text size='2'>No fields have been selected for preview, hence we would show all mandatory fields of {doctype} in the preview.</Text>
+        </div>}
+        <HStack align='center' pt='2'>
+            <TextField.Root placeholder='Search fields' className='w-full' size='2' value={search} onChange={e => setSearch(e.target.value)}>
+                <TextField.Slot>
+                    <BiSearch />
+                </TextField.Slot>
+            </TextField.Root>
+            <Button className='not-cal' type='button' onClick={handleUpdate} disabled={!hasChanged || loading}>
+                {loading ? <><Spinner /> Updating...</> : 'Update and Preview'}
+            </Button>
+        </HStack>
+        {error && <ErrorBanner error={error} />}
+
+        <FieldSelector eligibleFields={filteredFields} selectedFields={selectedFields} setSelectedFields={onFieldChange} />
+    </Stack>
+}
+
+const FieldSelector = ({ eligibleFields, selectedFields, setSelectedFields }: { eligibleFields: DocField[], selectedFields: string[], setSelectedFields: (fields: string[]) => void }) => {
+
+    return <ScrollArea className='h-[60vh]'>
+        <CheckboxCards.Root defaultValue={selectedFields} onValueChange={setSelectedFields} gap={"1"} size={"1"}>
+            {eligibleFields.map(field => <PreviewFieldRow field={field} key={field.fieldname} />)}
+        </CheckboxCards.Root>
+    </ScrollArea>
+
+}
+
+const PreviewFieldRow = ({ field }: { field: DocField }) => {
+    return <CheckboxCards.Item value={field.fieldname ?? ''}>
+        <Text>{field.label}</Text>
+        <Badge>{field.fieldtype}</Badge>
+    </CheckboxCards.Item>
+}
+
+const DocTypePreview = ({ doctype, docname, setDocname }: { doctype: string, docname: string, setDocname: (docname: string) => void }) => {
+
+    const { db } = useContext(FrappeContext) as FrappeConfig
+
+    useEffect(() => {
+        db.getLastDoc(doctype).then((doc) => {
+            setDocname(doc.name)
+        })
+    }, [doctype])
+
+
+    return <Stack>
+        <Heading size='3' className='not-cal'>Preview</Heading>
+        <LinkField
+            label='Select a Document'
+            doctype={doctype}
+            value={docname}
+            setValue={setDocname}
+        />
+        {docname && <DoctypeLinkRenderer doctype={doctype} docname={docname} />}
+    </Stack>
+
+}
+
+export default DocumentPreviewToolConfigurator

--- a/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
+++ b/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
@@ -27,6 +27,7 @@ export const SettingsSidebar = () => {
                     {/* <SettingsSidebarItem title="ERPNext" to='erpnext' /> */}
                     <SettingsSidebarItem title="HR" to='hr' />
                     <SettingsSidebarItem title='Document Notifications' to='document-notifications' />
+                    <SettingsSidebarItem title="Document Previews" to='document-previews' />
                     <SettingsSidebarItem title="Message Actions" to='message-actions' />
                     <SettingsSidebarItem title="Scheduled Messages" to='scheduled-messages' />
                     <SettingsSidebarItem title="Webhooks" to='webhooks' />

--- a/frontend/src/hooks/useDoctypeMeta.ts
+++ b/frontend/src/hooks/useDoctypeMeta.ts
@@ -2,7 +2,7 @@ import { DocType } from '@/types/Core/DocType'
 import { useFrappeGetCall } from 'frappe-react-sdk'
 
 const useDoctypeMeta = (doctype: string) => {
-    const { data, isLoading } = useFrappeGetCall<{ docs: DocType[] }>('frappe.desk.form.load.getdoctype', {
+    const { data, isLoading, mutate } = useFrappeGetCall<{ docs: DocType[] }>('frappe.desk.form.load.getdoctype', {
         doctype: doctype
     }, undefined, {
         // 24 hours
@@ -16,7 +16,8 @@ const useDoctypeMeta = (doctype: string) => {
     return {
         doc: data?.docs?.[0],
         childDocs,
-        isLoading
+        isLoading,
+        mutate
     }
 }
 

--- a/frontend/src/pages/settings/Integrations/DocumentPreviewTool.tsx
+++ b/frontend/src/pages/settings/Integrations/DocumentPreviewTool.tsx
@@ -1,0 +1,21 @@
+import DocumentPreviewToolConfigurator from "@/components/feature/DocumentPreviewToolConfigurator"
+import PageContainer from "@/components/layout/Settings/PageContainer"
+import SettingsContentContainer from "@/components/layout/Settings/SettingsContentContainer"
+import SettingsPageHeader from "@/components/layout/Settings/SettingsPageHeader"
+
+
+const DocumentPreviewTool = () => {
+    return (
+        <PageContainer>
+            <SettingsContentContainer>
+                <SettingsPageHeader
+                    title='Document Previews'
+                    description='Customise how document links are displayed in the chat. You can add/remove fields to be displayed in the preview.'
+                />
+                <DocumentPreviewToolConfigurator />
+            </SettingsContentContainer>
+        </PageContainer>
+    )
+}
+
+export const Component = DocumentPreviewTool

--- a/raven/api/document_link.py
+++ b/raven/api/document_link.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
 from frappe.desk.utils import slug
 from frappe.model.meta import no_value_fields, table_fields
 from frappe.utils import get_url
@@ -85,3 +86,50 @@ def get_preview_data(doctype, docname):
 			)
 
 	return formatted_preview_data
+
+
+@frappe.whitelist(methods=["POST"])
+def update_preview_fields(doctype: str, fields: list[str]):
+
+	meta = frappe.get_meta(doctype)
+
+	existing_preview_fields = [
+		field.fieldname
+		for field in meta.fields
+		if field.in_preview
+		and field.fieldtype not in no_value_fields
+		and field.fieldtype not in table_fields
+	]
+	fields_to_remove = set(existing_preview_fields) - set(fields)
+
+	for field in fields_to_remove:
+		delete_property_setter(doctype, field_name=field, property="in_preview")
+
+	for field in fields:
+		meta_df = meta.get_field(field)
+		if not meta_df:
+			continue
+
+		delete_property_setter(doctype, field_name=field, property="in_preview")
+
+		# Check if a property setter needs to be created for this field - if the field was already in preview, we don't need to do anything
+		is_in_preview_by_default = frappe.db.get_value(
+			"DocField", {"parent": doctype, "fieldname": field}, "in_preview"
+		)
+
+		if is_in_preview_by_default:
+			# No need to create a property setter
+			continue
+
+		# create a new property setter
+		frappe.make_property_setter(
+			{
+				"doctype": doctype,
+				"doctype_or_field": "DocField",
+				"fieldname": field,
+				"property": "in_preview",
+				"value": "1",
+				"property_type": "Check",
+			},
+			is_system_generated=False,
+		)


### PR DESCRIPTION
Allow users to configure document link previews easily from Raven.

Select a DocType to view it's fields and a live preview (last doc is automatically selected - users can change documents to view their previews).
Users can select fields that they want to see in the preview and click on the update button. This will then create or delete property setters and update the doctype meta as well as the preview.

![CleanShot 2025-01-03 at 03 01 05@2x](https://github.com/user-attachments/assets/95493ab3-4719-4bfe-817a-a1924d575d3d)
