### PR TITLE
feat(web): custom emojis

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,8 @@ const router = createBrowserRouter(
               <Route path=":ID" lazy={() => import('./pages/settings/Workspaces/ViewWorkspace')} />
             </Route>
 
+            <Route path="emojis" lazy={() => import('./pages/settings/CustomEmojis/CustomEmojiList')} />
+
             <Route path="bots" >
               <Route index lazy={() => import('./pages/settings/AI/BotList')} />
               <Route path="create" lazy={() => import('./pages/settings/AI/CreateBot')} />

--- a/frontend/src/components/common/EmojiPicker/AddCustomEmojiDialog.tsx
+++ b/frontend/src/components/common/EmojiPicker/AddCustomEmojiDialog.tsx
@@ -1,0 +1,169 @@
+import { CustomFile } from '@/components/feature/file-upload/FileDrop'
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { Stack } from '@/components/layout/Stack'
+import { RavenCustomEmoji } from '@/types/RavenMessaging/RavenCustomEmoji'
+import { Box, Button, Dialog, Flex, TextField, VisuallyHidden } from '@radix-ui/themes'
+import { FrappeConfig, FrappeContext, useFrappeCreateDoc, useFrappeFileUpload } from 'frappe-react-sdk'
+import { ErrorText, HelperText } from '../Form'
+import { Label } from '../Form'
+import { useContext, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { FileUploadBox } from '@/components/feature/userSettings/UploadImage/FileUploadBox'
+import { __ } from '@/utils/translations'
+import { Loader } from '../Loader'
+
+
+type Props = {
+    open: boolean
+    onClose: (refresh?: boolean) => void
+}
+
+const AddCustomEmojiDialog = ({ open, onClose }: Props) => {
+    return (
+        <Dialog.Root open={open} onOpenChange={onClose}>
+            <Dialog.Content>
+                <Dialog.Title>Add Emoji</Dialog.Title>
+                <VisuallyHidden>
+                    <Dialog.Description size='2'>
+                        Add a custom emoji to your chat.
+                    </Dialog.Description>
+                </VisuallyHidden>
+                <AddEmojiForm onClose={onClose} />
+            </Dialog.Content>
+        </Dialog.Root>
+    )
+}
+
+const AddEmojiForm = ({ onClose }: { onClose: (refresh?: boolean) => void }) => {
+
+    const { call } = useContext(FrappeContext) as FrappeConfig
+
+    const [image, setImage] = useState<CustomFile | undefined>(undefined)
+
+    const { register, handleSubmit, formState: { errors }, setValue, setError, setFocus } = useForm<RavenCustomEmoji>({
+        defaultValues: {
+            emoji_name: "",
+            keywords: ""
+        },
+        mode: 'onBlur'
+    })
+
+    const { createDoc, loading, error } = useFrappeCreateDoc<RavenCustomEmoji>()
+    const { upload, loading: uploading, error: uploadError } = useFrappeFileUpload()
+
+    const onSubmit = async (data: RavenCustomEmoji) => {
+        if (!image) return
+
+        const exists = await checkIfEmojiNameExists(data.emoji_name)
+        if (exists) {
+            setError('emoji_name', { message: `Emoji ${data.emoji_name} already exists.` }, { shouldFocus: true })
+            return
+        }
+
+        upload(image, {
+            doctype: "Raven Custom Emoji",
+            docname: data.emoji_name,
+            fieldname: "emoji_image",
+        }).then((file) => {
+            return createDoc('Raven Custom Emoji', {
+                ...data,
+                image: file.file_url
+            })
+        }).then(() => {
+            onClose(true)
+        })
+    }
+
+    const onImageChange = (file?: CustomFile) => {
+
+        if (file) {
+            setImage(file)
+            // Get the name of the file and set it as the emoji name
+            const name = file.name.split('.').slice(0, -1).join('.')
+            setValue('emoji_name', name, { shouldValidate: true })
+            setFocus('emoji_name')
+        } else {
+            setImage(undefined)
+        }
+    }
+
+    const checkIfEmojiNameExists = async (name: string) => {
+        const emoji = await call.get('frappe.client.get_count', {
+            doctype: 'Raven Custom Emoji',
+            filters: {
+                emoji_name: name
+            }
+        })
+        return emoji?.message > 0
+    }
+
+    return <form onSubmit={handleSubmit(onSubmit)}>
+        <Stack>
+            <ErrorBanner error={error} />
+            <ErrorBanner error={uploadError} />
+            <Stack gap='0'>
+                <Label htmlFor='emoji_image'>Emoji</Label>
+                <HelperText>An image of 128px by 128px works best.</HelperText>
+                <FileUploadBox
+                    file={image}
+                    onFileChange={onImageChange}
+                    accept={{ 'image/*': ['.jpeg', '.jpg', '.png', '.svg', '.gif'] }}
+                    maxFileSize={1}
+                    hideIfLimitReached={true}
+                />
+            </Stack>
+            <Stack>
+                <Box>
+                    <Label htmlFor='emoji_name' isRequired>Emoji Name</Label>
+                    <TextField.Root
+                        id='emoji_name'
+                        {...register('emoji_name', {
+                            required: 'Name is required',
+                            maxLength: {
+                                value: 20,
+                                message: 'Name must be less than 20 characters'
+                            },
+                            validate: async (value) => {
+                                const exists = await checkIfEmojiNameExists(value)
+                                return exists ? 'Emoji name already exists' : true
+                            }
+                        })}
+                        placeholder="e.g. jawdrop"
+                        aria-invalid={errors.emoji_name ? 'true' : 'false'}
+                    />
+                </Box>
+                {errors.emoji_name && <ErrorText>{errors.emoji_name?.message}</ErrorText>}
+            </Stack>
+
+            <Stack>
+                <Box>
+                    <Label htmlFor='keywords'>Keywords</Label>
+                    <TextField.Root
+                        id='keywords'
+                        {...register('keywords')}
+                        placeholder="e.g. shocked, surprised, omg"
+                        aria-invalid={errors.keywords ? 'true' : 'false'}
+                    />
+                </Box>
+                <HelperText>
+                    You will be able to search for this emoji by these keywords. (Optional)
+                </HelperText>
+                {errors.keywords && <ErrorText>{errors.keywords?.message}</ErrorText>}
+            </Stack>
+            <Flex gap="3" mt="4" justify="end">
+                <Dialog.Close disabled={loading || uploading}>
+                    <Button variant="soft" color="gray">
+                        {__("Cancel")}
+                    </Button>
+                </Dialog.Close>
+                <Button type='submit' disabled={loading || uploading}>
+                    {loading || uploading && <Loader />}
+                    {loading || uploading ? __("Saving") : __("Save")}
+                </Button>
+            </Flex>
+        </Stack>
+    </form>
+
+}
+
+export default AddCustomEmojiDialog

--- a/frontend/src/components/common/EmojiPicker/DeleteCustomEmojiDialog.tsx
+++ b/frontend/src/components/common/EmojiPicker/DeleteCustomEmojiDialog.tsx
@@ -1,0 +1,46 @@
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { HStack } from '@/components/layout/Stack'
+import { AlertDialog, Button, IconButton } from '@radix-ui/themes'
+import { useFrappeDeleteDoc } from 'frappe-react-sdk'
+import { BiTrash } from 'react-icons/bi'
+
+type Props = {
+    emojiID: string
+    onDelete: () => void
+}
+
+const DeleteCustomEmojiDialog = ({ emojiID, onDelete }: Props) => {
+
+    const { deleteDoc, loading, error } = useFrappeDeleteDoc()
+
+    const handleDelete = async () => {
+        await deleteDoc('Raven Custom Emoji', emojiID)
+        onDelete()
+    }
+
+    return (
+        <AlertDialog.Root>
+            <AlertDialog.Trigger>
+                <IconButton color='red' variant='soft' size='2' className='group-hover:visible invisible'>
+                    <BiTrash />
+                </IconButton>
+            </AlertDialog.Trigger>
+            <AlertDialog.Content>
+                <AlertDialog.Title>Delete Emoji</AlertDialog.Title>
+                <AlertDialog.Description>Are you sure you want to delete this emoji?</AlertDialog.Description>
+                {error && <ErrorBanner error={error} />}
+                <HStack justify='end' gap='2' pt='2'>
+                    <AlertDialog.Cancel>
+                        <Button disabled={loading} color='gray' variant='soft'>Cancel</Button>
+                    </AlertDialog.Cancel>
+                    <AlertDialog.Action onClick={handleDelete} disabled={loading}>
+                        <Button color='red' disabled={loading}>Delete</Button>
+                    </AlertDialog.Action>
+                </HStack>
+
+            </AlertDialog.Content>
+        </AlertDialog.Root>
+    )
+}
+
+export default DeleteCustomEmojiDialog

--- a/frontend/src/components/common/EmojiPicker/EmojiPicker.tsx
+++ b/frontend/src/components/common/EmojiPicker/EmojiPicker.tsx
@@ -1,20 +1,59 @@
+import { useIsDesktop } from "@/hooks/useMediaQuery"
 import { useTheme } from "@/ThemeProvider"
+import { RavenCustomEmoji } from "@/types/RavenMessaging/RavenCustomEmoji"
 import Picker from '@emoji-mart/react'
+import { useFrappeGetDocList } from "frappe-react-sdk"
+import { useMemo } from "react"
 
-const EmojiPicker = ({ onSelect }: { onSelect: (emoji: string) => void }) => {
+const EmojiPicker = ({ onSelect, allowCustomEmojis = true }: { onSelect: (emoji: string, is_custom: boolean, emoji_name?: string) => void, allowCustomEmojis?: boolean }) => {
     const { appearance } = useTheme()
 
     const onEmojiSelect = (emoji: any) => {
-        onSelect(emoji.native)
+        if (emoji.native) {
+            onSelect(emoji.native, false)
+        } else {
+            onSelect(emoji.src, true, emoji.id)
+        }
     }
+
+    const isDesktop = useIsDesktop()
+
+    const { data } = useFrappeGetDocList<RavenCustomEmoji>("Raven Custom Emoji", {
+        fields: ["name", "image", "keywords"],
+        limit: 1000
+    }, allowCustomEmojis ? `custom-emojis` : null, {
+        revalidateOnFocus: false,
+        revalidateIfStale: false,
+        revalidateOnReconnect: false,
+    })
+
+    const customEmojis = useMemo(() => {
+        if (!allowCustomEmojis) return undefined
+
+        if (!data) return undefined
+
+        return [{
+            id: "Custom",
+            name: "Custom",
+            emojis: data.map((emoji) => ({
+                id: emoji.name,
+                name: emoji.name,
+                keywords: emoji.keywords?.split(','),
+                skins: [{ src: emoji.image }]
+            }))
+        }]
+
+    }, [data, allowCustomEmojis])
 
     return <Picker
         maxFrequentRows={2}
         set='apple'
+        custom={customEmojis}
         onEmojiSelect={onEmojiSelect}
         skinTonePosition='search'
         theme={appearance === 'inherit' ? 'auto' : appearance}
-        autoFocus={true}
+        autoFocus={isDesktop}
+        showPreview={isDesktop}
     />
 
 

--- a/frontend/src/components/feature/DocumentPreviewToolConfigurator.tsx
+++ b/frontend/src/components/feature/DocumentPreviewToolConfigurator.tsx
@@ -105,8 +105,6 @@ const DocTypePreviewEditor = ({ doctype, docname, eligibleFields, previewFields,
             })
     }
 
-    console.log(previewFields)
-
 
     return <Stack>
         {previewFields.length === 0 && <div>

--- a/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
@@ -15,12 +15,16 @@ export type EmojiType = {
 
 async function search(value: string, maxResults: number = 10): Promise<EmojiType[]> {
     const emojis = await SearchIndex.search(value, { maxResults: maxResults, caller: undefined })
-    const results = emojis.map((emoji: any) => {
-        return {
-            shortcodes: emoji.skins[0].shortcodes,
-            emoji: emoji.skins[0].native,
-            name: emoji.name,
-            id: emoji.id,
+
+    const results: EmojiType[] = []
+    emojis.forEach((emoji: any) => {
+        if (emoji && emoji.skins[0].native) {
+            results.push({
+                shortcodes: emoji.skins[0].shortcodes,
+                emoji: emoji.skins[0].native,
+                name: emoji.name,
+                id: emoji.id,
+            })
         }
     })
 
@@ -34,16 +38,19 @@ function getTopFavoriteEmojis(maxResults: number = 10): EmojiType[] {
     // @ts-expect-error
     const emojis = FrequentlyUsed.get({ maxFrequentRows: 1, perLine: maxResults })
 
-    const results: EmojiType[] = emojis.map((emoji: string) => {
+    const results: EmojiType[] = []
 
+    emojis.forEach((emoji: string) => {
         // @ts-expect-error
         const e = SearchIndex.get(emoji)
 
-        return {
-            id: e.id,
-            shortcodes: e.skins[0].shortcodes,
-            emoji: e.skins[0].native,
-            name: e.name,
+        if (e && e.skins[0].native) {
+            results.push({
+                id: e.id,
+                shortcodes: e.skins[0].shortcodes,
+                emoji: e.skins[0].native,
+                name: e.name,
+            })
         }
     })
 

--- a/frontend/src/components/feature/chat/ChatInput/RightToolbarButtons.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/RightToolbarButtons.tsx
@@ -111,6 +111,14 @@ const EmojiPickerButton = () => {
         return null
     }
 
+    const onSelect = (emoji: string, is_custom: boolean, emoji_name?: string) => {
+        if (is_custom) {
+            editor.chain().focus().setImage({ src: emoji, alt: emoji_name, title: emoji_name }).run()
+        } else {
+            editor.chain().focus().insertContent(emoji).run()
+        }
+    }
+
     return <Popover.Root>
         <Popover.Trigger>
             <IconButton
@@ -126,7 +134,7 @@ const EmojiPickerButton = () => {
         <Popover.Content>
             <Inset>
                 <Suspense fallback={<Loader />}>
-                    <EmojiPicker onSelect={(e) => editor.chain().focus().insertContent(e).run()} />
+                    <EmojiPicker onSelect={onSelect} allowCustomEmojis={false} />
                 </Suspense>
             </Inset>
         </Popover.Content>

--- a/frontend/src/components/feature/chat/ChatMessage/ActionModals/ReactionAnalyticsModal.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/ActionModals/ReactionAnalyticsModal.tsx
@@ -7,12 +7,10 @@ import { useGetUser } from "@/hooks/useGetUser"
 
 export const ReactionAnalyticsModal = ({ reactions }: ReactionAnalyticsDialogProps) => {
 
-    const { reaction_emojis, all_reacted_members } = useMemo(() => {
-        const reaction_emojis = reactions.map((reaction: ReactionObject) => reaction.reaction);
-        const all_reacted_members = reactions.flatMap(({ reaction, users }: ReactionObject) =>
-            users.map((user: string) => ({ user, reaction }))
+    const all_reacted_members = useMemo(() => {
+        return reactions.flatMap(({ reaction, users, is_custom, emoji_name }: ReactionObject) =>
+            users.map((user: string) => ({ user, reaction, is_custom, emoji_name }))
         );
-        return { reaction_emojis, all_reacted_members };
     }, [reactions]);
 
     return (
@@ -20,10 +18,14 @@ export const ReactionAnalyticsModal = ({ reactions }: ReactionAnalyticsDialogPro
             <Tabs.Root defaultValue="All">
                 <Flex direction="column" gap="4">
                     <Tabs.List>
-                        <TabTrigger emojiStr="All" />
-                        {reaction_emojis.map((emojiStr) => {
-                            const reaction = reactions.find((r) => r.reaction === emojiStr);
-                            return <TabTrigger key={emojiStr} emojiStr={emojiStr} count={reaction?.count} />;
+                        <TabTrigger emojiSrc="All" emojiName="All" />
+                        {reactions.map((reaction) => {
+                            return <TabTrigger
+                                key={reaction.reaction}
+                                emojiSrc={reaction.reaction}
+                                isCustom={reaction.is_custom}
+                                emojiName={reaction.emoji_name}
+                                count={reaction.count} />;
                         })}
                     </Tabs.List>
                     <Box>
@@ -32,7 +34,7 @@ export const ReactionAnalyticsModal = ({ reactions }: ReactionAnalyticsDialogPro
                         </Tabs.Content>
                         {reactions.map((reaction) => (
                             <Tabs.Content key={reaction.reaction} value={reaction.reaction}>
-                                <UserList users={reaction.users.map((user) => ({ user }))} />
+                                <UserList users={reaction.users.map((user) => ({ user, reaction: reaction.reaction, is_custom: reaction.is_custom, emoji_name: reaction.emoji_name }))} />
                             </Tabs.Content>
                         ))}
                     </Box>
@@ -42,10 +44,10 @@ export const ReactionAnalyticsModal = ({ reactions }: ReactionAnalyticsDialogPro
     );
 };
 
-const TabTrigger = ({ emojiStr, count }: { emojiStr: string; count?: number }) => (
-    <Tabs.Trigger value={emojiStr} className="text-gray-11">
+const TabTrigger = ({ emojiSrc, count, emojiName, isCustom = false }: { emojiSrc: string; count?: number, emojiName: string, isCustom?: boolean }) => (
+    <Tabs.Trigger value={emojiSrc} className="text-gray-11" title={emojiName}>
         <Flex gap="2" align="center" justify="center">
-            <Text size="3">{emojiStr}</Text>
+            {isCustom ? <img src={emojiSrc} alt={emojiName} className="w-[1.2rem] h-[1.2rem] object-contain object-center" /> : <Text size="3">{emojiName}</Text>}
             {count && <Text>{count}</Text>}
         </Flex>
     </Tabs.Trigger>
@@ -54,20 +56,22 @@ const TabTrigger = ({ emojiStr, count }: { emojiStr: string; count?: number }) =
 interface UserItemProps {
     user: string;
     reaction?: string;
+    is_custom?: boolean;
+    emoji_name?: string;
 }
 const UserList = ({ users }: { users: UserItemProps[] }) => (
     <Box className="overflow-hidden overflow-y-scroll h-[50vh] sm:h-64">
         <Flex direction="column" gap="2">
             <Flex direction="column">
                 {users.map((user, index) => (
-                    <UserItem key={index} user={user.user} reaction={user.reaction} />
+                    <UserItem key={index} user={user.user} reaction={user.reaction} is_custom={user.is_custom} emoji_name={user.emoji_name} />
                 ))}
             </Flex>
         </Flex>
     </Box>
 );
 
-const UserItem = ({ user, reaction }: UserItemProps) => {
+const UserItem = ({ user, reaction, is_custom, emoji_name }: UserItemProps) => {
     const userDetails = useGetUser(user)
     const userName = userDetails?.full_name ?? user;
 
@@ -80,7 +84,9 @@ const UserItem = ({ user, reaction }: UserItemProps) => {
                         {userName}
                     </Text>
                 </Flex>
-                {reaction && (
+                {is_custom ? (
+                    <img src={reaction} alt={emoji_name} title={emoji_name} className="mr-3 w-[1.4rem] h-[1.4rem] object-contain object-center" />
+                ) : (
                     <Text className="pr-3" size="3" weight="medium">
                         {reaction}
                     </Text>

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageReactionAnalytics.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageReactionAnalytics.tsx
@@ -15,7 +15,10 @@ export const useMessageReactionAnalytics = () => {
     const reactions: ReactionObject[] = useMemo(() => {
         //Parse the string to a JSON object and get an array of reactions
         const parsed_json = JSON.parse(message_reactions ?? '{}') as Record<string, ReactionObject>
-        return Object.values(parsed_json)
+        return Object.entries(parsed_json).map(([key, value]) => ({
+            ...value,
+            emoji_name: key
+        }))
     }, [message_reactions])
 
     const onClose = useCallback(() => {

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/EmojiPickerButton.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx'
 const EmojiPicker = lazy(() => import('@/components/common/EmojiPicker/EmojiPicker'))
 
 interface EmojiPickerButtonProps {
-    saveReaction: (emoji: string) => void,
+    saveReaction: (emoji: string, is_custom: boolean, emoji_name?: string) => void,
     isOpen: boolean
     setIsOpen: (open: boolean) => void,
     iconButtonProps?: IconButtonProps,
@@ -22,8 +22,8 @@ export const EmojiPickerButton = ({ saveReaction, isOpen, setIsOpen, iconButtonP
         setIsOpen(false)
     }
 
-    const onEmojiClick = (emoji: string) => {
-        saveReaction(emoji)
+    const onEmojiClick = (emoji: string, is_custom: boolean, emoji_name?: string) => {
+        saveReaction(emoji, is_custom, emoji_name)
         onClose()
     }
 

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
@@ -50,10 +50,12 @@ export const QuickActions = ({ message, onReply, onEdit, isEmojiPickerOpen, setI
         e.target.dispatchEvent(evt);
     }
 
-    const onEmojiReact = (emoji: string) => {
+    const onEmojiReact = (emoji: string, is_custom: boolean = false, emoji_name?: string) => {
         call.post('raven.api.reactions.react', {
             message_id: message?.name,
-            reaction: emoji
+            reaction: emoji,
+            is_custom,
+            emoji_name
         }).catch((err) => {
             toast.error("Could not react to message.", {
                 description: getErrorMessage(err)

--- a/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
+++ b/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
@@ -21,6 +21,7 @@ export const SettingsSidebar = () => {
                 <SettingsGroup title="Workspace" icon={BiBuildings}>
                     <SettingsSidebarItem title="Workspaces" to='workspaces' />
                     <SettingsSidebarItem title="Users" to='users' />
+                    <SettingsSidebarItem title="Emojis" to='emojis' />
                 </SettingsGroup>
                 <SettingsSeparator />
                 <SettingsGroup title='Integrations' icon={BsBoxes}>

--- a/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
@@ -18,12 +18,14 @@ export type FileUploadBoxProps = FlexProps & {
     /** Takes input MIME type as 'key' & array of extensions as 'value'; empty array - all extensions supported */
     accept?: Accept
     /** Maximum file size in mb that can be selected */
-    maxFileSize?: number
+    maxFileSize?: number,
+    /** Hide the file upload box if the file size limit is reached */
+    hideIfLimitReached?: boolean
 }
 
 export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
 
-    const { file, onFileChange, accept, maxFileSize, children, ...compProps } = props
+    const { file, onFileChange, accept, maxFileSize, children, hideIfLimitReached, ...compProps } = props
     const [onDragEnter, setOnDragEnter] = useState(false)
 
     const fileSizeValidator = (file: any) => {
@@ -73,6 +75,10 @@ export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
         })
     }
 
+    const toHide = hideIfLimitReached && file
+
+    const supportedFormats = accept ? `Supported formats: ${Object.values(accept).flat().join(", ")}` : __("Supported formats: {0}, {1}, {2}", [".jpeg", ".jpg", ".png"])
+
     return (
         <Flex direction="column" pt='2' gap='2' {...getRootProps()} {...compProps}>
             <Flex
@@ -83,7 +89,7 @@ export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
                     width: "100%",
                     height: "150px",
                 }}
-                display={"flex"}>
+                display={toHide ? "none" : "flex"}>
                 <Flex gap={'1'}>
                     <Text as="span" size="2" color="gray">
                         {__("Drag and drop your file here or")}
@@ -94,12 +100,12 @@ export const FileUploadBox = forwardRef((props: FileUploadBoxProps, ref) => {
                 </Flex>
                 <input type="file" style={{ display: "none" }} {...getInputProps()} />
             </Flex>
-            <Flex justify={'between'}>
+            <Flex justify={'between'} display={toHide ? "none" : "flex"}>
                 <Text as="span" size="1" color="gray">
-                    {__("Supported formats: {0}, {1}, {2}", [".jpeg", ".jpg", ".png"])}
+                    {supportedFormats}
                 </Text>
                 <Text as="span" size="1" color="gray">
-                    {__("Maximum file size: {0}MB", [10])}
+                    {__("Maximum file size: {0}MB", [maxFileSize])}
                 </Text>
             </Flex>
             {file && <FileItem file={file} uploadProgress={fileUploadProgress} removeFile={() => removeFile(file.fileID)} />}

--- a/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
+++ b/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
@@ -141,6 +141,7 @@ const AddWorkspaceForm = ({ onClose }: { onClose: (workspaceID?: string) => void
                         <FileUploadBox
                             file={image}
                             onFileChange={setImage}
+                            hideIfLimitReached
                             accept={{ 'image/*': ['.jpeg', '.jpg', '.png', '.svg', '.webp'] }}
                             maxFileSize={10}
                         />

--- a/frontend/src/pages/settings/CustomEmojis/CustomEmojiList.tsx
+++ b/frontend/src/pages/settings/CustomEmojis/CustomEmojiList.tsx
@@ -1,0 +1,114 @@
+import AddCustomEmojiDialog from '@/components/common/EmojiPicker/AddCustomEmojiDialog'
+import DeleteCustomEmojiDialog from '@/components/common/EmojiPicker/DeleteCustomEmojiDialog'
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { EmptyState, EmptyStateDescription, EmptyStateIcon, EmptyStateTitle } from '@/components/layout/EmptyState/EmptyListViewState'
+import { TableLoader } from '@/components/layout/Loaders/TableLoader'
+import PageContainer from '@/components/layout/Settings/PageContainer'
+import SettingsContentContainer from '@/components/layout/Settings/SettingsContentContainer'
+import SettingsPageHeader from '@/components/layout/Settings/SettingsPageHeader'
+import { HStack } from '@/components/layout/Stack'
+import { RavenCustomEmoji } from '@/types/RavenMessaging/RavenCustomEmoji'
+import { getDateObject } from '@/utils/dateConversions/utils'
+import { Button, Table, Text, Link } from '@radix-ui/themes'
+import { useFrappeGetDocList } from 'frappe-react-sdk'
+import { useState } from 'react'
+import { LuSmilePlus } from 'react-icons/lu'
+
+const CustomEmojiList = () => {
+
+    const { data, isLoading, error, mutate } = useFrappeGetDocList<RavenCustomEmoji>("Raven Custom Emoji", {
+        fields: ["name", "emoji_name", "image", "keywords", "owner", "creation"],
+        orderBy: {
+            field: "modified",
+            order: "desc"
+        }
+    }, undefined, {
+        errorRetryCount: 2
+    })
+
+    const [open, setOpen] = useState(false)
+
+    const onAddEmoji = (refresh: boolean = false) => {
+        if (refresh) {
+            mutate()
+        }
+        setOpen(false)
+    }
+
+    const onDeleteEmoji = () => {
+        mutate()
+    }
+
+    return (
+        <PageContainer>
+            <SettingsContentContainer>
+                <SettingsPageHeader
+                    title='Emojis'
+                    description={<>Add custom emojis to use for your reactions. PNG, SVG and GIFs supported. <br />Need help finding one? Download from <Link href='https://emoji.gg' target='_blank'>Emoji.gg</Link>.</>}
+                    actions={<Button onClick={() => setOpen(true)}>
+                        Upload
+                    </Button>}
+                />
+                {isLoading && !error && <TableLoader columns={2} />}
+                <ErrorBanner error={error} />
+                {data && data.length > 0 && <CustomEmojisTable emojis={data} onDelete={onDeleteEmoji} />}
+                {data?.length === 0 && <EmptyState>
+                    <EmptyStateIcon>
+                        <LuSmilePlus />
+                    </EmptyStateIcon>
+                    <EmptyStateTitle>Emojis</EmptyStateTitle>
+                    <EmptyStateDescription>
+                        Personalize your chats with custom emojis.
+                        <br />
+                        Upload your own or download from <Link href='https://emoji.gg' target='_blank'>Emoji.gg</Link>.
+                    </EmptyStateDescription>
+                    <Button className='not-cal' onClick={() => setOpen(true)}>
+                        Upload
+                    </Button>
+                </EmptyState>}
+                <AddCustomEmojiDialog open={open} onClose={onAddEmoji} />
+            </SettingsContentContainer>
+        </PageContainer>
+    )
+}
+
+const CustomEmojisTable = ({ emojis, onDelete }: { emojis: RavenCustomEmoji[], onDelete: () => void }) => {
+    return (
+        <Table.Root variant="surface" className='rounded-sm animate-fadein'>
+            <Table.Header>
+                <Table.Row>
+                    <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell>Keywords</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell>Uploaded By</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell>Added</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {emojis?.map((emoji) => (
+                    <Table.Row key={emoji.name} className='hover:bg-gray-1 dark:hover:bg-gray-1 group'>
+                        <Table.Cell>
+                            <HStack align='center' gap='2'>
+                                <img src={emoji.image} alt={emoji.emoji_name} className='h-8 w-8 object-contain object-center' />
+                                <Text weight='medium'>:{emoji.emoji_name}:</Text>
+                            </HStack>
+                        </Table.Cell>
+                        <Table.Cell align='center'>
+                            <Text className='flex h-full items-center'>{emoji.keywords}</Text>
+                        </Table.Cell>
+                        <Table.Cell align='center'>
+                            <Text className='flex h-full items-center'>{emoji.owner}</Text>
+                        </Table.Cell>
+                        <Table.Cell align='center'>
+                            <Text className='flex h-full items-center'>{getDateObject(emoji.creation).format("MMM Do, YYYY")}</Text>
+                        </Table.Cell>
+                        <Table.Cell align='center'>
+                            <DeleteCustomEmojiDialog emojiID={emoji.name} onDelete={onDelete} />
+                        </Table.Cell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Table.Root>
+    )
+}
+export const Component = CustomEmojiList

--- a/frontend/src/pages/settings/CustomEmojis/CustomEmojiList.tsx
+++ b/frontend/src/pages/settings/CustomEmojis/CustomEmojiList.tsx
@@ -10,11 +10,13 @@ import { HStack } from '@/components/layout/Stack'
 import { RavenCustomEmoji } from '@/types/RavenMessaging/RavenCustomEmoji'
 import { getDateObject } from '@/utils/dateConversions/utils'
 import { Button, Table, Text, Link } from '@radix-ui/themes'
-import { useFrappeGetDocList } from 'frappe-react-sdk'
+import { useFrappeGetDocList, useSWRConfig } from 'frappe-react-sdk'
 import { useState } from 'react'
 import { LuSmilePlus } from 'react-icons/lu'
 
 const CustomEmojiList = () => {
+
+    const { mutate: globalMutate } = useSWRConfig()
 
     const { data, isLoading, error, mutate } = useFrappeGetDocList<RavenCustomEmoji>("Raven Custom Emoji", {
         fields: ["name", "emoji_name", "image", "keywords", "owner", "creation"],
@@ -31,12 +33,14 @@ const CustomEmojiList = () => {
     const onAddEmoji = (refresh: boolean = false) => {
         if (refresh) {
             mutate()
+            globalMutate('custom-emojis')
         }
         setOpen(false)
     }
 
     const onDeleteEmoji = () => {
         mutate()
+        globalMutate('custom-emojis')
     }
 
     return (

--- a/frontend/src/types/RavenMessaging/RavenCustomEmoji.ts
+++ b/frontend/src/types/RavenMessaging/RavenCustomEmoji.ts
@@ -1,0 +1,19 @@
+
+export interface RavenCustomEmoji{
+	creation: string
+	name: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	Image : Attach Image	*/
+	image: string
+	/**	Emoji Name : Data	*/
+	emoji_name: string
+	/**	Keywords : Data	*/
+	keywords?: string
+}

--- a/frontend/src/types/RavenMessaging/RavenMessageReaction.ts
+++ b/frontend/src/types/RavenMessaging/RavenMessageReaction.ts
@@ -18,4 +18,6 @@ export interface RavenMessageReaction{
 	message: string
 	/**	Channel ID : Link - Raven Channel	*/
 	channel_id?: string
+	/**	Is Custom : Check	*/
+	is_custom?: 0 | 1
 }

--- a/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.js
+++ b/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Raven Custom Emoji", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.json
+++ b/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.json
@@ -1,0 +1,93 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:emoji_name",
+ "creation": "2025-01-04 03:06:50.669037",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "image",
+  "emoji_name",
+  "keywords"
+ ],
+ "fields": [
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 1
+  },
+  {
+   "fieldname": "emoji_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Emoji Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "keywords",
+   "fieldtype": "Data",
+   "label": "Keywords"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-01-04 03:09:49.286615",
+ "modified_by": "Administrator",
+ "module": "Raven Messaging",
+ "name": "Raven Custom Emoji",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Raven User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Raven User",
+   "share": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Raven Admin",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.py
+++ b/raven/raven_messaging/doctype/raven_custom_emoji/raven_custom_emoji.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class RavenCustomEmoji(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		emoji_name: DF.Data
+		image: DF.AttachImage
+		keywords: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/raven/raven_messaging/doctype/raven_custom_emoji/test_raven_custom_emoji.py
+++ b/raven/raven_messaging/doctype/raven_custom_emoji/test_raven_custom_emoji.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestRavenCustomEmoji(UnitTestCase):
+	"""
+	Unit tests for RavenCustomEmoji.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestRavenCustomEmoji(IntegrationTestCase):
+	"""
+	Integration tests for RavenCustomEmoji.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.json
+++ b/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.json
@@ -10,7 +10,8 @@
   "reaction",
   "reaction_escaped",
   "message",
-  "channel_id"
+  "channel_id",
+  "is_custom"
  ],
  "fields": [
   {
@@ -42,11 +43,17 @@
    "fieldtype": "Link",
    "label": "Channel ID",
    "options": "Raven Channel"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_custom",
+   "fieldtype": "Check",
+   "label": "Is Custom"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-16 13:46:42.137770",
+ "modified": "2025-01-04 04:43:58.861388",
  "modified_by": "Administrator",
  "module": "Raven Messaging",
  "name": "Raven Message Reaction",

--- a/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.py
+++ b/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.py
@@ -19,19 +19,16 @@ class RavenMessageReaction(Document):
 		from frappe.types import DF
 
 		channel_id: DF.Link | None
+		is_custom: DF.Check
 		message: DF.Link
 		reaction: DF.Data
 		reaction_escaped: DF.Data | None
 	# end: auto-generated types
 
-	def before_save(self):
-		"""Escape the reaction to UTF-8 (XXXX)"""
-		self.reaction_escaped = self.reaction.encode("unicode-escape").decode("utf-8").replace("\\u", "")
-
 	def after_insert(self):
 		# Update the count for the current reaction
-		calculate_message_reaction(self.message)
+		calculate_message_reaction(self.message, self.channel_id)
 
 	def after_delete(self):
 		# Update the count for the current reaction
-		calculate_message_reaction(self.message)
+		calculate_message_reaction(self.message, self.channel_id)


### PR DESCRIPTION
Added support for using custom emojis in reactions on the web app.

PNGs, GIFs and JPGs supported.

Added a new checkbox in the Reactions doctype for "is_custom". If it's a custom emoji, we do not need to escape the characters and instead store the "name" of the emoji in the `reaction_escaped` field. This is then used to show the "name" of the reaction in the tooltip.

![CleanShot 2025-01-04 at 05 46 14@2x](https://github.com/user-attachments/assets/d37364cd-fc3f-4c6d-9baa-176c89e90611)

![CleanShot 2025-01-04 at 05 46 35@2x](https://github.com/user-attachments/assets/efe260d2-3754-4a21-97ff-9000a2700f63)

![CleanShot 2025-01-04 at 05 46 56@2x](https://github.com/user-attachments/assets/087b27c9-7b3e-4aca-8f63-ff7269fcdb33)

![CleanShot 2025-01-04 at 05 47 21@2x](https://github.com/user-attachments/assets/e635b5bb-903f-4783-b286-71207a1f7fa3)
