### PR TITLE
fix(web): colors for workspaces and improved visibility

### DIFF
--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -61,7 +61,7 @@ export const ChannelList = ({ channels }: ChannelListProps) => {
                     }}
                 >
                     <div ref={ref} className="flex gap-0.5 flex-col">
-                        {filteredChannels.length === 0 ? <Text size='1' className="pl-1" color='gray'>{__("No channels found")}</Text> : null}
+                        {filteredChannels.length === 0 ? <Text size='1' className="pl-1" color='gray'>{__("No channels in this workspace.")}</Text> : null}
                         {filteredChannels.map((channel: ChannelWithUnreadCount) => <ChannelItem
                             channel={channel}
                             key={channel.name} />)}

--- a/frontend/src/components/layout/Sidebar/WorkspacesSidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/WorkspacesSidebar.tsx
@@ -8,6 +8,8 @@ import clsx from 'clsx'
 import { useContext, useMemo } from 'react'
 import useUnreadMessageCount from '@/hooks/useUnreadMessageCount'
 import { ChannelListContext, ChannelListContextType } from '@/utils/channel/ChannelListProvider'
+import { generateAvatarColor } from '@/components/feature/selectDropdowns/GenerateAvatarColor'
+import { getInitials } from '@/components/common/UserAvatar'
 
 const WorkspacesSidebar = () => {
 
@@ -78,7 +80,7 @@ const WorkspaceItem = ({ workspace }: { workspace: WorkspaceFields & { unread_co
     }
 
     return <HStack position='relative' align='center' className='group'>
-        <Box className={clsx('w-1 bg-gray-12 rounded-r-full dark:bg-gray-12 absolute sm:-left-3 -left-3.5 group-hover:h-4 transition-all duration-200 ease-ease-out-cubic',
+        <Box className={clsx('w-1.5 bg-gray-12 rounded-r-full dark:bg-gray-12 absolute sm:-left-3 -left-3.5 group-hover:h-4 transition-all duration-200 ease-ease-out-cubic',
             isSelected ? 'h-[90%] group-hover:h-[90%] group-active:h-[90%]' : 'group-active:h-4',
             workspace.unread_count > 0 && 'h-1.5'
         )} />
@@ -102,13 +104,23 @@ const WorkspaceItem = ({ workspace }: { workspace: WorkspaceFields & { unread_co
 }
 
 const WorkspaceLogo = ({ workspace_name, logo }: { workspace_name: string, logo: string }) => {
+
+    const { color, fallback } = useMemo(() => {
+        const fallback = getInitials(workspace_name)
+        const color = generateAvatarColor(workspace_name)
+
+        return {
+            color,
+            fallback
+        }
+    }, [workspace_name])
     return <Box>
         <Avatar
             size={{ sm: '3', md: '3' }}
             className={clsx('hover:shadow-sm transition-all duration-200')}
-            color='gray'
+            color={color}
             loading='eager'
-            fallback={workspace_name.charAt(0)}
+            fallback={fallback}
             src={logo}
         />
     </Box>


### PR DESCRIPTION
Workspace icons have randomly generated colors based on their name. The side element to denote the current selected workspace has also been increased.

<img width="326" alt="image" src="https://github.com/user-attachments/assets/da4d220e-ac03-4025-af69-fc87b17e98e4" />
