### PR TITLE
fix: update channel list via realtime events

### DIFF
--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -2,7 +2,6 @@ import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList, Si
 import { SidebarBadge, SidebarViewMoreButton } from "../../layout/Sidebar/SidebarComp"
 import { CreateChannelButton } from "./CreateChannelModal"
 import { useContext, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { ChannelListContext, ChannelListContextType } from "../../../utils/channel/ChannelListProvider"
 import { ChannelIcon } from "@/utils/layout/channelIcon"
 import { ContextMenu, Flex, Text } from "@radix-ui/themes"
 import { useLocation, useParams } from "react-router-dom"
@@ -20,7 +19,6 @@ interface ChannelListProps {
 
 export const ChannelList = ({ channels }: ChannelListProps) => {
 
-    const { mutate } = useContext(ChannelListContext) as ChannelListContextType
     const [showData, setShowData] = useStickyState(true, 'expandChannelList')
 
     const toggle = () => setShowData(d => !d)
@@ -49,7 +47,7 @@ export const ChannelList = ({ channels }: ChannelListProps) => {
                         <SidebarGroupLabel>{__("Channels")}</SidebarGroupLabel>
                     </Flex>
                     <Flex align='center' gap='1'>
-                        <CreateChannelButton updateChannelList={mutate} />
+                        <CreateChannelButton />
                         <SidebarViewMoreButton onClick={toggle} expanded={showData} />
                     </Flex>
                 </Flex>

--- a/frontend/src/components/feature/channels/CreateChannelModal.tsx
+++ b/frontend/src/components/feature/channels/CreateChannelModal.tsx
@@ -21,7 +21,7 @@ interface ChannelCreationForm {
     type: 'Public' | 'Private' | 'Open'
 }
 
-export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: VoidFunction }) => {
+export const CreateChannelButton = () => {
 
     const [isOpen, setIsOpen] = useState(false)
 
@@ -36,7 +36,7 @@ export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: 
                 </IconButton>
             </Dialog.Trigger>
             <Dialog.Content className={DIALOG_CONTENT_CLASS}>
-                <CreateChannelContent updateChannelList={updateChannelList}
+                <CreateChannelContent
                     isOpen={isOpen}
                     setIsOpen={setIsOpen} />
             </Dialog.Content>
@@ -52,7 +52,7 @@ export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: 
             </DrawerTrigger>
             <DrawerContent>
                 <div className='pb-16 overflow-y-scroll min-h-96'>
-                    <CreateChannelContent updateChannelList={updateChannelList}
+                    <CreateChannelContent
                         isOpen={isOpen}
                         setIsOpen={setIsOpen} />
                 </div>
@@ -65,7 +65,7 @@ export const CreateChannelButton = ({ updateChannelList }: { updateChannelList: 
 }
 
 
-const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { updateChannelList: VoidFunction, setIsOpen: (v: boolean) => void, isOpen: boolean }) => {
+const CreateChannelContent = ({ isOpen, setIsOpen }: { setIsOpen: (v: boolean) => void, isOpen: boolean }) => {
 
 
     const { workspaceID } = useParams()
@@ -90,7 +90,6 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
         if (channel_name) {
             // Update channel list when name is provided.
             // Also navigate to new channel
-            updateChannelList()
             navigate(`/${workspace}/${channel_name}`)
             mutate(["channel_members", channel_name])
         }
@@ -112,6 +111,22 @@ const CreateChannelContent = ({ updateChannelList, isOpen, setIsOpen }: { update
             workspace: workspaceID
         }).then(result => {
             if (result) {
+                mutate("channel_list", (data) => {
+                    return {
+                        message: {
+                            ...data.message,
+                            channels: [
+                                ...data.message.channels,
+                                {
+                                    ...result,
+                                }
+                            ]
+                        }
+                    }
+
+                }, {
+                    revalidate: false
+                })
                 toast.success(__("Channel created"))
                 onClose(result.name, workspaceID)
             }

--- a/frontend/src/utils/users/UserListProvider.tsx
+++ b/frontend/src/utils/users/UserListProvider.tsx
@@ -22,7 +22,7 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
         revalidateOnReconnect: false,
     })
 
-    const [newUpdatesAvailable, setNewUpdatesAvailable] = useState(false)
+    const [newUpdatesAvailable, setNewUpdatesAvailable] = useState(0)
 
     useEffect(() => {
         let timeout: NodeJS.Timeout | undefined
@@ -31,7 +31,7 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
                 mutate()
                 // Mutate the channel list as well
                 globalMutate(`channel_list`)
-                setNewUpdatesAvailable(false)
+                setNewUpdatesAvailable(0)
             }, 1000) // 1 second
         }
         return () => clearTimeout(timeout)
@@ -42,7 +42,7 @@ export const UserListProvider = ({ children }: PropsWithChildren) => {
      * Instead, throttle this - wait for all events to subside
      */
     useFrappeDocTypeEventListener('Raven User', () => {
-        setNewUpdatesAvailable(true)
+        setNewUpdatesAvailable((n) => n + 1)
     })
 
     const { users, enabledUsers } = useMemo(() => {

--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from raven.utils import delete_channel_members_cache, is_channel_member
+from raven.utils import delete_channel_members_cache
 
 
 class RavenChannel(Document):
@@ -55,6 +55,16 @@ class RavenChannel(Document):
 
 		delete_channel_members_cache(self.name)
 
+		if not self.is_thread:
+			# Update the channel list for all users
+			frappe.publish_realtime(
+				"channel_list_updated",
+				{
+					"channel_id": self.name,
+				},
+				after_commit=True,
+			)
+
 		# If the channel was a thread, (i.e. a message exists with the same name), remove the 'is_thread' flag from the message
 		if self.is_thread and frappe.db.exists("Raven Message", {"name": self.name}):
 			message_channel_id = frappe.get_cached_value("Raven Message", self.name, "channel_id")
@@ -87,6 +97,16 @@ class RavenChannel(Document):
 		"""
 		# add current user as channel member
 		if not frappe.flags.in_install and not self.flags.do_not_add_member:
+
+			if self.type in ("Open", "Public") and not self.is_thread:
+				# Update the channel list for all users
+				frappe.publish_realtime(
+					"channel_list_updated",
+					{
+						"channel_id": self.name,
+					},
+					after_commit=True,
+				)
 
 			if self.is_direct_message == 1:
 				# Add both users as members


### PR DESCRIPTION
Added a new real-time event for channel list update since it was not being updated when a member was added to a private channel.

Also added revalidation on focus for mobile devices.

Closes #1299 
