### PR TITLE
feat: store push notification token on site

### DIFF
--- a/frontend/public/frappe-push-notification.js
+++ b/frontend/public/frappe-push-notification.js
@@ -245,12 +245,14 @@ class FrappePushNotification {
     async registerTokenHandler(token) {
         try {
             let response = await fetch(
-                "/api/method/frappe.push_notification.subscribe?fcm_token=" +
-                token +
-                "&project_name=" +
-                this.projectName,
+                "/api/method/raven.api.notification.subscribe",
                 {
-                    method: "GET",
+                    method: "POST",
+                    body: JSON.stringify({
+                        fcm_token: token,
+                        environment: "Web",
+                        device_information: navigator.userAgent,
+                    }),
                     headers: {
                         "Content-Type": "application/json",
                     },
@@ -272,12 +274,12 @@ class FrappePushNotification {
     async unregisterTokenHandler(token) {
         try {
             let response = await fetch(
-                "/api/method/frappe.push_notification.unsubscribe?fcm_token=" +
-                token +
-                "&project_name=" +
-                this.projectName,
+                "/api/method/raven.api.notification.unsubscribe",
                 {
-                    method: "GET",
+                    method: "POST",
+                    body: JSON.stringify({
+                        fcm_token: token,
+                    }),
                     headers: {
                         "Content-Type": "application/json",
                     },

--- a/frontend/src/types/Raven/RavenPushToken.ts
+++ b/frontend/src/types/Raven/RavenPushToken.ts
@@ -1,0 +1,21 @@
+
+export interface RavenPushToken{
+	creation: string
+	name: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	User : Link - User	*/
+	user: string
+	/**	Environment : Select	*/
+	environment: "Web" | "Mobile"
+	/**	Device Information : Data	*/
+	device_information?: string
+	/**	FCM Token : Small Text	*/
+	fcm_token: string
+}

--- a/frontend/src/types/Raven/RavenSettings.ts
+++ b/frontend/src/types/Raven/RavenSettings.ts
@@ -35,4 +35,6 @@ export interface RavenSettings{
 	show_if_a_user_is_on_leave?: 0 | 1
 	/**	OAuth Client : Link - OAuth Client	*/
 	oauth_client?: string
+	/**	Push Notification Service : Select	*/
+	push_notification_service?: "Frappe Cloud" | "Raven"
 }

--- a/raven/api/notification.py
+++ b/raven/api/notification.py
@@ -22,3 +22,38 @@ def toggle_push_notification_for_channel(member: str, allow_notifications: 0 | 1
 			return member_doc
 	else:
 		frappe.throw(_("Push notifications are not supported in the current framework version"))
+
+
+@frappe.whitelist(methods=["POST"])
+def subscribe(fcm_token: str, environment: str, device_information: str | None = None) -> None:
+	"""
+	Add the FCM token to the database
+	"""
+
+	# Check if the FCM token already exists
+	if frappe.db.exists("Raven Push Token", {"fcm_token": fcm_token, "user": frappe.session.user}):
+		return
+
+	# Add the FCM token to the database
+	frappe.get_doc(
+		{
+			"doctype": "Raven Push Token",
+			"fcm_token": fcm_token,
+			"user": frappe.session.user,
+			"environment": environment,
+			"device_information": device_information,
+		}
+	).insert()
+
+	return "Subscribed"
+
+
+@frappe.whitelist(methods=["POST"])
+def unsubscribe(fcm_token: str) -> None:
+	"""
+	Remove the FCM token from the database
+	"""
+
+	frappe.db.delete("Raven Push Token", {"fcm_token": fcm_token, "user": frappe.session.user})
+
+	return "Unsubscribed"

--- a/raven/raven/doctype/raven_push_token/raven_push_token.js
+++ b/raven/raven/doctype/raven_push_token/raven_push_token.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Raven Push Token", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/raven/raven/doctype/raven_push_token/raven_push_token.json
+++ b/raven/raven/doctype/raven_push_token/raven_push_token.json
@@ -1,0 +1,89 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2025-02-07 14:16:36.666515",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "user",
+  "environment",
+  "device_information",
+  "column_break_wmua",
+  "fcm_token"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "default": "Web",
+   "fieldname": "environment",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Environment",
+   "options": "Web\nMobile",
+   "reqd": 1
+  },
+  {
+   "fieldname": "device_information",
+   "fieldtype": "Data",
+   "label": "Device Information"
+  },
+  {
+   "fieldname": "column_break_wmua",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "fcm_token",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "FCM Token",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-02-07 14:21:09.951155",
+ "modified_by": "Administrator",
+ "module": "Raven",
+ "name": "Raven Push Token",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Raven User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/raven/raven/doctype/raven_push_token/raven_push_token.py
+++ b/raven/raven/doctype/raven_push_token/raven_push_token.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+from raven.api.notification import are_push_notifications_enabled
+
+
+class RavenPushToken(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		device_information: DF.Data | None
+		environment: DF.Literal["Web", "Mobile"]
+		fcm_token: DF.SmallText
+		user: DF.Link
+	# end: auto-generated types
+
+	def after_insert(self):
+		"""
+		If the push service is Frappe Cloud and is enabled, then send the token to the Frappe Cloud API
+		"""
+		push_service = self.get_push_service()
+
+		if push_service == "Frappe Cloud" and are_push_notifications_enabled():
+			try:
+				from frappe.push_notification import subscribe
+
+				subscribe(self.fcm_token, "raven")
+			except ImportError:
+				# push notifications are not supported in the current framework version
+				pass
+			except Exception:
+				frappe.log_error("Failed to subscribe to Frappe Cloud push notifications")
+
+	def on_trash(self):
+		"""
+		If the push service is Frappe Cloud and is enabled, then delete the token from the Frappe Cloud API
+		"""
+		push_service = self.get_push_service()
+
+		if push_service == "Frappe Cloud" and are_push_notifications_enabled():
+			try:
+				from frappe.push_notification import unsubscribe
+
+				unsubscribe(self.fcm_token, "raven")
+			except ImportError:
+				# push notifications are not supported in the current framework version
+				pass
+			except Exception:
+				frappe.log_error("Failed to unsubscribe from Frappe Cloud push notifications")
+
+	def get_push_service(self) -> str:
+		"""
+		Get the push service from the push service settings
+		"""
+		push_service = frappe.db.get_single_value("Raven Settings", "push_notification_service")
+
+		if not push_service:
+			push_service = "Frappe Cloud"
+
+		return push_service

--- a/raven/raven/doctype/raven_push_token/test_raven_push_token.py
+++ b/raven/raven/doctype/raven_push_token/test_raven_push_token.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestRavenPushToken(UnitTestCase):
+	"""
+	Unit tests for RavenPushToken.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestRavenPushToken(IntegrationTestCase):
+	"""
+	Integration tests for RavenPushToken.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/raven/raven/doctype/raven_settings/raven_settings.json
+++ b/raven/raven/doctype/raven_settings/raven_settings.json
@@ -25,7 +25,9 @@
   "attendance_and_leaves_section",
   "show_if_a_user_is_on_leave",
   "raven_mobile_tab",
-  "oauth_client"
+  "oauth_client",
+  "push_notifications_tab",
+  "push_notification_service"
  ],
  "fields": [
   {
@@ -143,12 +145,24 @@
    "label": "Company Workspace Mapping",
    "mandatory_depends_on": "eval:doc.auto_create_department_channel",
    "options": "Raven HR Company Workspace"
+  },
+  {
+   "fieldname": "push_notifications_tab",
+   "fieldtype": "Tab Break",
+   "label": "Push Notifications"
+  },
+  {
+   "default": "Frappe Cloud",
+   "fieldname": "push_notification_service",
+   "fieldtype": "Select",
+   "label": "Push Notification Service",
+   "options": "Frappe Cloud\nRaven"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-07 23:29:30.189530",
+ "modified": "2025-02-07 14:27:46.335513",
  "modified_by": "Administrator",
  "module": "Raven",
  "name": "Raven Settings",

--- a/raven/raven/doctype/raven_settings/raven_settings.py
+++ b/raven/raven/doctype/raven_settings/raven_settings.py
@@ -28,6 +28,7 @@ class RavenSettings(Document):
 		openai_api_key: DF.Password | None
 		openai_organisation_id: DF.Data | None
 		openai_project_id: DF.Data | None
+		push_notification_service: DF.Literal["Frappe Cloud", "Raven"]
 		show_if_a_user_is_on_leave: DF.Check
 		show_raven_on_desk: DF.Check
 		tenor_api_key: DF.Data | None


### PR DESCRIPTION
Added a new DocType "Raven Push Token" which stores the FCM tokens before sending it to Frappe Cloud's relay service. API on the service worker for push notifications has been changed to point to new APIs in Raven.