### PR TITLE
fix: fetch unread count every 2 minutes, revalidate on focus every mi…

### DIFF
--- a/frontend/src/hooks/useUnreadMessageCount.ts
+++ b/frontend/src/hooks/useUnreadMessageCount.ts
@@ -33,7 +33,11 @@ const useUnreadMessageCount = () => {
     const { data: unread_count, mutate: updateCount } = useFrappeGetCall<{ message: UnreadCountData }>("raven.api.raven_message.get_unread_count_for_channels",
         undefined,
         'unread_channel_count', {
-        revalidateOnFocus: false,
+        // Revalidate on focus every minute
+        focusThrottleInterval: 60 * 1000,
+        // Fetch unread count every 2 minutes
+        refreshInterval: 2 * 60 * 1000,
+        revalidateOnFocus: true,
         revalidateOnReconnect: true,
     })
 


### PR DESCRIPTION
This might be tweaked later, but for now we can fetch unread count every 2 minutes (refresh interval) and revalidate when the tab comes in focus every minute