### PR TITLE
feat: allow external users to be tagged in messages

### DIFF
--- a/frontend/src/components/feature/chat/ChatInput/MentionList.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/MentionList.tsx
@@ -1,6 +1,5 @@
 import { UserAvatar } from '@/components/common/UserAvatar'
 import { useIsUserActive } from '@/hooks/useIsUserActive'
-import { UserFields } from '@/utils/users/UserListProvider'
 import { Flex, Text, Theme } from '@radix-ui/themes'
 import { ReactRendererOptions } from '@tiptap/react'
 import { clsx } from 'clsx'
@@ -9,6 +8,9 @@ import {
     useRef,
     useState,
 } from 'react'
+import { MemberSuggestions } from './Tiptap'
+import { HStack } from '@/components/layout/Stack'
+import { BiUserX } from 'react-icons/bi'
 
 export default forwardRef((props: ReactRendererOptions['props'], ref) => {
 
@@ -65,7 +67,7 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
                 className='shadow-lg dark:bg-panel-solid bg-white overflow-y-scroll max-h-96 rounded-md'
             >
                 {props?.items.length
-                    ? props.items.map((item: UserFields, index: number) => (
+                    ? props.items.map((item: MemberSuggestions, index: number) => (
                         <MentionItem
                             item={item}
                             index={index}
@@ -82,7 +84,7 @@ export default forwardRef((props: ReactRendererOptions['props'], ref) => {
     )
 })
 
-const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: UserFields, selectItem: (index: number) => void }) => {
+const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { itemsLength: number, selectedIndex: number, index: number, item: MemberSuggestions, selectItem: (index: number) => void }) => {
 
     const isActive = useIsUserActive(item.name)
 
@@ -116,6 +118,10 @@ const MentionItem = ({ item, index, selectItem, selectedIndex, itemsLength }: { 
             isActive={isActive}
             availabilityStatus={item.availability_status}
         />
-        <Text as='span' weight='medium' size='2'> {item.full_name}</Text>
+        <HStack width='100%' justify='between' align='center' gap='2'>
+            <Text as='span' weight='medium' size='2'> {item.full_name}</Text>
+            <Text as='span' color='gray'>{!item.is_member && <BiUserX title='This user is not a member of the channel' />}</Text>
+        </HStack>
+
     </Flex>
 }

--- a/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -88,18 +88,28 @@ export const ChannelMention = Mention.extend({
         }
     })
 
+export interface MemberSuggestions extends UserFields {
+    is_member: boolean
+}
+
 const Tiptap = ({ isEdit, slotBefore, fileProps, onMessageSend, channelMembers, onUserType, channelID, replyMessage, clearReplyMessage, placeholder = 'Type a message...', messageSending, sessionStorageKey = 'tiptap-editor', disableSessionStorage = false, defaultText = '' }: TiptapEditorProps) => {
 
     const { enabledUsers } = useContext(UserListContext)
 
-    const channelMembersRef = useRef<UserFields[]>([])
+    const channelMembersRef = useRef<MemberSuggestions[]>([])
 
     useEffect(() => {
         if (channelMembers) {
-            // Filter enabled users to only include users that are in the channel
-            channelMembersRef.current = enabledUsers.filter((user) => user.name in channelMembers)
+            // Sort the user list so that members are at the top
+            channelMembersRef.current = enabledUsers.map((user) => ({
+                ...user,
+                is_member: user.name in channelMembers
+            })).sort((a, b) => a.is_member ? -1 : 1)
         } else {
-            channelMembersRef.current = enabledUsers
+            channelMembersRef.current = enabledUsers.map((user) => ({
+                ...user,
+                is_member: true
+            }))
         }
     }, [channelMembers, enabledUsers])
 


### PR DESCRIPTION
You can now tag users who are not part of the channel. An icon will be shown to indicate that the user is not a member of the current channel.

<img width="261" alt="image" src="https://github.com/user-attachments/assets/b0c22d30-b23e-4f21-ac49-a79575624728" />
