### PR TITLE
fix: allow non-admins to add members to private channels

### DIFF
--- a/frontend/src/components/feature/channel-member-details/add-members/AddMembersButton.tsx
+++ b/frontend/src/components/feature/channel-member-details/add-members/AddMembersButton.tsx
@@ -25,12 +25,12 @@ export const AddMembersButton = ({ channelData, ...props }: AddMembersButtonProp
         return (
             <Dialog.Root open={open} onOpenChange={setOpen}>
                 <Dialog.Trigger>
-                    <Button variant="ghost" size='1' {...props} className={clsx("text-nowrap", props.className)}>
+                    <Button variant="ghost" size='1' {...props} className={clsx("text-nowrap not-cal", props.className)}>
                         Add Members
                     </Button>
                 </Dialog.Trigger>
 
-                <Dialog.Content className={clsx(DIALOG_CONTENT_CLASS, 'static')}>
+                <Dialog.Content className={'static'}>
                     <AddChannelMembersModalContent
                         onClose={onClose}
                     />

--- a/raven/api/raven_channel_member.py
+++ b/raven/api/raven_channel_member.py
@@ -32,7 +32,6 @@ def add_channel_members(channel_id: str, members: list[str]):
 	"""
 	Add members to a channel
 	"""
-	frappe.has_permission("Raven Channel", doc=channel_id, ptype="write", throw=True)
 
 	# Since this is a bulk operation, we need to disable cache invalidation (will be handled manually) and ignore permissions (since we already have permission to add members)
 
@@ -41,7 +40,7 @@ def add_channel_members(channel_id: str, members: list[str]):
 			{"doctype": "Raven Channel Member", "channel_id": channel_id, "user_id": member}
 		)
 		member_doc.flags.ignore_cache_invalidation = True
-		member_doc.insert(ignore_permissions=True)
+		member_doc.insert()
 
 	delete_channel_members_cache(channel_id)
 	return True


### PR DESCRIPTION
We used to allow this earlier, but I had added a permission check for channel write on adding members. Removing that fixed the issue.