### PR TITLE
feat: allow anyone to create channels in a workspace

### DIFF
--- a/frontend/src/components/feature/channels/CreateChannelModal.tsx
+++ b/frontend/src/components/feature/channels/CreateChannelModal.tsx
@@ -70,7 +70,7 @@ const CreateChannelContent = ({ isOpen, setIsOpen }: { setIsOpen: (v: boolean) =
 
     const { workspaceID } = useParams()
 
-    const { data: isAdmin } = useFrappeGetCall<{ message: boolean }>('raven.api.workspaces.is_workspace_admin', { workspace: workspaceID }, workspaceID ? undefined : null)
+    const { data: canCreateChannel } = useFrappeGetCall<{ message: boolean }>('raven.api.workspaces.can_create_channel', { workspace: workspaceID }, workspaceID ? undefined : null)
 
     const { mutate } = useSWRConfig()
     let navigate = useNavigate()
@@ -173,7 +173,7 @@ const CreateChannelContent = ({ isOpen, setIsOpen }: { setIsOpen: (v: boolean) =
         <FormProvider {...methods}>
             <form onSubmit={handleSubmit(onSubmit)}>
                 <Flex direction='column' gap='4' py='4'>
-                    {!isAdmin?.message && <CustomCallout
+                    {!canCreateChannel?.message && <CustomCallout
                         iconChildren={<BiInfoCircle size='18' />}
                         rootProps={{ color: 'yellow', variant: 'surface' }}
                         textChildren={<Text>You cannot create a new channel since you are not an admin of this workspace. Ask an admin to create a channel or make you an admin.</Text>}
@@ -284,7 +284,7 @@ const CreateChannelContent = ({ isOpen, setIsOpen }: { setIsOpen: (v: boolean) =
                             {__("Cancel")}
                         </Button>
                     </Dialog.Close>
-                    <Button type='submit' disabled={creatingChannel || !isAdmin?.message}>
+                    <Button type='submit' disabled={creatingChannel || !canCreateChannel?.message}>
                         {creatingChannel && <Loader className="text-white" />}
                         {creatingChannel ? __("Saving") : __("Save")}
                     </Button>

--- a/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
+++ b/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@/components/layout/Stack'
 import { useIsDesktop } from '@/hooks/useMediaQuery'
 import { RavenWorkspace } from '@/types/Raven/RavenWorkspace'
 import { __ } from '@/utils/translations'
-import { Box, Button, Dialog, Flex, RadioGroup, Text, TextArea, TextField } from '@radix-ui/themes'
+import { Box, Button, Checkbox, Dialog, Flex, RadioGroup, Text, TextArea, TextField } from '@radix-ui/themes'
 import { useFrappeCreateDoc, useFrappeFileUpload, useFrappeUpdateDoc, useSWRConfig } from 'frappe-react-sdk'
 import { useState } from 'react'
 import { Controller, FormProvider, useForm } from 'react-hook-form'
@@ -135,6 +135,26 @@ const AddWorkspaceForm = ({ onClose }: { onClose: (workspaceID?: string) => void
                         <HelperText>
                             {helperText}
                         </HelperText>
+                    </Stack>
+                    <Stack py='2'>
+                        <Text as="label" size="2">
+                            <Controller
+                                control={control}
+                                name={"only_admins_can_create_channels"}
+                                render={({ field: { value, onChange, onBlur, name, disabled, ref } }) => (
+                                    <Checkbox
+                                        checked={value ? true : false}
+                                        disabled={disabled}
+                                        name={name}
+                                        aria-invalid={errors.only_admins_can_create_channels ? 'true' : 'false'}
+                                        aria-describedby={errors.only_admins_can_create_channels ? 'only-admins-can-create-channels-error' : undefined}
+                                        aria-required={errors.only_admins_can_create_channels ? 'true' : 'false'}
+                                        onBlur={onBlur}
+                                        ref={ref}
+                                        onCheckedChange={(v) => onChange(v ? 1 : 0)}
+                                    />
+                                )} />&nbsp; Only admins can create channels in this workspace?
+                        </Text>
                     </Stack>
                     <Stack gap='0'>
                         <Label htmlFor='workspace_image'>Workspace Logo</Label>

--- a/frontend/src/components/feature/workspaces/WorkspaceEditForm.tsx
+++ b/frontend/src/components/feature/workspaces/WorkspaceEditForm.tsx
@@ -2,7 +2,7 @@ import { ErrorText, HelperText, Label } from '@/components/common/Form'
 import { HStack, Stack } from '@/components/layout/Stack'
 import { RavenWorkspace } from '@/types/Raven/RavenWorkspace'
 import { __ } from '@/utils/translations'
-import { Box, Card, Flex, RadioGroup, Text, TextArea } from '@radix-ui/themes'
+import { Box, Card, Checkbox, Flex, RadioGroup, Text, TextArea } from '@radix-ui/themes'
 import { Controller, useFormContext } from 'react-hook-form'
 import { WorkspaceLogoField } from './WorkspaceLogoField'
 
@@ -62,6 +62,27 @@ const WorkspaceEditForm = () => {
                         <HelperText>
                             {__("When a workspace is set to private, it can only be viewed or joined by invitation.\nWhen a workspace is set to public, anyone can join the workspace and view it's channels.")}
                         </HelperText>
+                    </Stack>
+
+                    <Stack className='max-w-lg'>
+                        <Text as="label" size="2">
+                            <Controller
+                                control={control}
+                                name={"only_admins_can_create_channels"}
+                                render={({ field: { value, onChange, onBlur, name, disabled, ref } }) => (
+                                    <Checkbox
+                                        checked={value ? true : false}
+                                        disabled={disabled}
+                                        name={name}
+                                        aria-invalid={errors.only_admins_can_create_channels ? 'true' : 'false'}
+                                        aria-describedby={errors.only_admins_can_create_channels ? 'only-admins-can-create-channels-error' : undefined}
+                                        aria-required={errors.only_admins_can_create_channels ? 'true' : 'false'}
+                                        onBlur={onBlur}
+                                        ref={ref}
+                                        onCheckedChange={(v) => onChange(v ? 1 : 0)}
+                                    />
+                                )} />&nbsp; Only admins can create channels in this workspace?
+                        </Text>
                     </Stack>
                 </Stack>
             </Stack>

--- a/frontend/src/types/Raven/RavenWorkspace.ts
+++ b/frontend/src/types/Raven/RavenWorkspace.ts
@@ -20,4 +20,6 @@ export interface RavenWorkspace{
 	description?: string
 	/**	Logo : Attach Image	*/
 	logo?: string
+	/**	Only allow admins to create channels in the workspace : Check - If unchecked, any workspace member can create a channel	*/
+	only_admins_can_create_channels?: 0 | 1
 }

--- a/raven/api/workspaces.py
+++ b/raven/api/workspaces.py
@@ -83,6 +83,18 @@ def is_workspace_admin(workspace: str):
 
 
 @frappe.whitelist()
+def can_create_channel(workspace: str):
+	"""
+	Checks if the current user can create a channel in a workspace
+	"""
+	workspace_doc = frappe.get_doc("Raven Workspace", workspace)
+	if workspace_doc.only_admins_can_create_channels:
+		return is_workspace_admin(workspace)
+
+	return True
+
+
+@frappe.whitelist()
 def fetch_workspace_members(workspace: str):
 	"""
 	Gets all members of a workspace

--- a/raven/permissions.py
+++ b/raven/permissions.py
@@ -137,6 +137,9 @@ def channel_has_permission(doc, user=None, ptype=None):
 			workspace_member = get_workspace_member(doc.workspace, user)
 			if workspace_member and workspace_member.get("is_admin"):
 				return True
+			# If the workspace allows any member to create a channel, then the user can create a channel
+			if not frappe.db.get_value("Raven Workspace", doc.workspace, "only_admins_can_create_channels"):
+				return True
 
 		if ptype == "delete" or ptype == "write":
 			# Only channel admins can update or delete a channel

--- a/raven/raven/doctype/raven_workspace/raven_workspace.json
+++ b/raven/raven/doctype/raven_workspace/raven_workspace.json
@@ -11,7 +11,8 @@
   "can_only_join_via_invite",
   "description",
   "column_break_svnf",
-  "logo"
+  "logo",
+  "only_admins_can_create_channels"
  ],
  "fields": [
   {
@@ -50,6 +51,13 @@
    "fieldname": "description",
    "fieldtype": "Small Text",
    "label": "Description"
+  },
+  {
+   "default": "0",
+   "description": "If unchecked, any workspace member can create a channel",
+   "fieldname": "only_admins_can_create_channels",
+   "fieldtype": "Check",
+   "label": "Only allow admins to create channels in the workspace"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -60,7 +68,7 @@
   }
  ],
  "make_attachments_public": 1,
- "modified": "2024-12-06 17:19:48.638139",
+ "modified": "2025-02-15 17:41:08.057640",
  "modified_by": "Administrator",
  "module": "Raven",
  "name": "Raven Workspace",

--- a/raven/raven/doctype/raven_workspace/raven_workspace.py
+++ b/raven/raven/doctype/raven_workspace/raven_workspace.py
@@ -17,6 +17,7 @@ class RavenWorkspace(Document):
 		can_only_join_via_invite: DF.Check
 		description: DF.SmallText | None
 		logo: DF.AttachImage | None
+		only_admins_can_create_channels: DF.Check
 		type: DF.Literal["Public", "Private"]
 		workspace_name: DF.Data
 	# end: auto-generated types


### PR DESCRIPTION
By default, any workspace member can create channels in a workspace. 

If users want only admins to be allowed to create channels in a workspace, they can do so by checking the "Only admins can create channels in this workspace" setting. This is available on both the create workspace and edit workspace flow.

![CleanShot 2025-02-15 at 17 57 29@2x](https://github.com/user-attachments/assets/33fc3742-c253-448e-99d0-6b6d0f93a6f1)
