### PR TITLE
perf: use unique URL in files instead of file URL

### DIFF
--- a/frontend/src/components/feature/userSettings/UploadImage/UploadImageModal.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/UploadImageModal.tsx
@@ -38,7 +38,7 @@ export const UploadImageModal = ({ uploadImage, label = 'Upload Image', doctype,
                 },
                 isPrivate: true,
             }).then((res) => {
-                uploadImage(res.file_url)
+                uploadImage(res.file_url + "?fid=" + res.name)
             }).catch((e) => {
                 setFileError(e)
             })

--- a/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
+++ b/frontend/src/components/feature/workspaces/AddWorkspaceForm.tsx
@@ -41,10 +41,13 @@ const AddWorkspaceForm = ({ onClose }: { onClose: (workspaceID?: string) => void
                         doctype: 'Raven Workspace',
                         docname: res.name,
                         fieldname: 'logo',
+                        otherData: {
+                            optimize: '1',
+                        },
                         isPrivate: true,
                     }).then((fileRes) => {
                         return updateDoc("Raven Workspace", res.name, {
-                            logo: fileRes.file_url
+                            logo: fileRes.file_url + "?fid=" + fileRes.name
                         })
                     })
                 }

--- a/raven/api/upload_file.py
+++ b/raven/api/upload_file.py
@@ -102,7 +102,7 @@ def upload_file_with_message():
 
 	message_doc.reload()
 
-	message_doc.file = file_doc.file_url
+	message_doc.file = file_doc.unique_url
 
 	if file_doc.file_type in fileExt:
 


### PR DESCRIPTION
Changes:

1. Store the Unique URL instead of file URL for profile, workspace and messages
2. Compress images for workspace


cc: @ankush