### PR TITLE
perf: update message stream without waiting for websocket event

### DIFF
--- a/frontend/src/components/feature/chat/ChatInput/useSendMessage.ts
+++ b/frontend/src/components/feature/chat/ChatInput/useSendMessage.ts
@@ -1,9 +1,10 @@
 import { useFrappePostCall } from 'frappe-react-sdk'
 import { Message } from '../../../../../../types/Messaging/Message'
+import { RavenMessage } from '@/types/RavenMessaging/RavenMessage'
 
-export const useSendMessage = (channelID: string, noOfFiles: number, uploadFiles: () => Promise<void>, handleCancelReply: VoidFunction, selectedMessage?: Message | null) => {
+export const useSendMessage = (channelID: string, noOfFiles: number, uploadFiles: () => Promise<RavenMessage[]>, onMessageSent: (messages: RavenMessage[]) => void, selectedMessage?: Message | null) => {
 
-    const { call, loading } = useFrappePostCall('raven.api.raven_message.send_message')
+    const { call, loading } = useFrappePostCall<{ message: RavenMessage }>('raven.api.raven_message.send_message')
 
     const sendMessage = async (content: string, json?: any): Promise<void> => {
 
@@ -16,15 +17,15 @@ export const useSendMessage = (channelID: string, noOfFiles: number, uploadFiles
                 is_reply: selectedMessage ? 1 : 0,
                 linked_message: selectedMessage ? selectedMessage.name : null
             })
-                .then(() => handleCancelReply())
+                .then((res) => onMessageSent([res.message]))
                 .then(() => uploadFiles())
-                .then(() => {
-                    handleCancelReply()
+                .then((res) => {
+                    onMessageSent(res)
                 })
         } else if (noOfFiles > 0) {
             return uploadFiles()
-                .then(() => {
-                    handleCancelReply()
+                .then((res) => {
+                    onMessageSent(res)
                 })
         } else {
             return Promise.resolve()

--- a/frontend/src/components/feature/chat/ChatStream/ChatStream.tsx
+++ b/frontend/src/components/feature/chat/ChatStream/ChatStream.tsx
@@ -4,7 +4,7 @@ import { EditMessageDialog, useEditMessage } from '../ChatMessage/MessageActions
 import { MessageItem } from '../ChatMessage/MessageItem'
 import { ChannelHistoryFirstMessage } from '@/components/layout/EmptyState/EmptyState'
 import useChatStream from './useChatStream'
-import { useRef } from 'react'
+import { MutableRefObject } from 'react'
 import { Loader } from '@/components/common/Loader'
 import ChatStreamLoader from './ChatStreamLoader'
 import clsx from 'clsx'
@@ -67,13 +67,11 @@ type Props = {
     channelID: string,
     replyToMessage: (message: Message) => void,
     showThreadButton?: boolean,
+    scrollRef: MutableRefObject<HTMLDivElement | null>,
     pinnedMessagesString?: string
 }
 
-const ChatStream = ({ channelID, replyToMessage, showThreadButton = true, pinnedMessagesString }: Props) => {
-
-
-    const scrollRef = useRef<HTMLDivElement | null>(null)
+const ChatStream = ({ channelID, replyToMessage, showThreadButton = true, pinnedMessagesString, scrollRef }: Props) => {
 
     const { messages, hasOlderMessages, loadOlderMessages, goToLatestMessages, hasNewMessages, error, loadNewerMessages, isLoading, highlightedMessage, scrollToMessage } = useChatStream(channelID, scrollRef, pinnedMessagesString)
     const { setDeleteMessage, ...deleteProps } = useDeleteMessage()

--- a/frontend/src/components/feature/chat/ChatStream/useChatStream.ts
+++ b/frontend/src/components/feature/chat/ChatStream/useChatStream.ts
@@ -7,7 +7,7 @@ import { useDebounce } from '@/hooks/useDebounce'
 import { UserContext } from '@/utils/auth/UserProvider'
 import { useIsMobile } from '@/hooks/useMediaQuery'
 
-interface GetMessagesResponse {
+export interface GetMessagesResponse {
     message: {
         messages: Message[],
         has_old_messages: boolean

--- a/frontend/src/hooks/useActiveSocketConnection.ts
+++ b/frontend/src/hooks/useActiveSocketConnection.ts
@@ -1,0 +1,34 @@
+import { FrappeConfig, FrappeContext, useSWR } from "frappe-react-sdk"
+import { useContext, useRef } from "react"
+import { toast } from "sonner"
+
+// Check the socket connection every 2 minutes if the user focuses back on the page
+export const useActiveSocketConnection = () => {
+    const { socket } = useContext(FrappeContext) as FrappeConfig
+
+    const socketConnectionCount = useRef(0)
+
+    useSWR('socket_test', () => {
+        return socket?.connected ? true : Promise.reject(new Error('Socket not connected'))
+    }, {
+
+        onSuccess: () => {
+            socketConnectionCount.current = 0
+        },
+        onError: (error) => {
+            console.log("Socket connection failed", socketConnectionCount.current)
+            // If the socket connection fails more than 2 times, then show an error message
+            if (socketConnectionCount.current === 2) {
+                toast.error("Realtime events are not working. Please try refreshing the page.", {
+                    duration: 5000
+                })
+            } else {
+                // Else try to connect to socket
+                socket?.connect()
+                socketConnectionCount.current += 1
+            }
+
+        },
+        errorRetryCount: 3
+    })
+}

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -11,6 +11,7 @@ import { useFetchActiveUsersRealtime } from '@/hooks/fetchers/useFetchActiveUser
 import { useIsMobile } from '@/hooks/useMediaQuery'
 import { showNotification } from '@/utils/pushNotifications'
 import MessageActionController from '@/components/feature/message-actions/MessageActionController'
+import { useActiveSocketConnection } from '@/hooks/useActiveSocketConnection'
 
 const AddRavenUsersPage = lazy(() => import('@/pages/AddRavenUsersPage'))
 
@@ -44,6 +45,8 @@ const MainPageContent = () => {
     }, [])
 
     const isMobile = useIsMobile()
+
+    useActiveSocketConnection()
 
     return <UserListProvider>
         <ChannelListProvider>

--- a/frontend/src/types/RavenMessaging/RavenMessage.ts
+++ b/frontend/src/types/RavenMessaging/RavenMessage.ts
@@ -1,6 +1,6 @@
 import { RavenMention } from './RavenMention'
 
-export interface RavenMessage{
+export interface RavenMessage {
 	creation: string
 	name: string
 	modified: string
@@ -28,7 +28,7 @@ export interface RavenMessage{
 	/**	Is Thread : Check - This message starts a thread	*/
 	is_thread?: 0 | 1
 	/**	Message Type : Select	*/
-	message_type?: "Text" | "Image" | "File" | "Poll" | "System"
+	message_type: "Text" | "Image" | "File" | "Poll" | "System"
 	/**	Content : Long Text	*/
 	content?: string
 	/**	File : Attach	*/

--- a/raven/api/raven_message.py
+++ b/raven/api/raven_message.py
@@ -40,7 +40,7 @@ def send_message(channel_id, text, is_reply=False, linked_message=None, json_con
 				}
 			)
 		doc.insert()
-		return "message sent"
+		return doc
 
 
 @frappe.whitelist()

--- a/raven/api/upload_file.py
+++ b/raven/api/upload_file.py
@@ -150,4 +150,4 @@ def upload_file_with_message():
 
 	message_doc.save()
 
-	return message_doc.name
+	return message_doc


### PR DESCRIPTION
On sending a message, we update the chat stream with the new message as soon as we get a response from the API call. This isn't optimistic )we still wait for the API call), but it's much better UX wise since we don't need to wait for the web socket event to be broadcast and received.

If websocket is not connected, Raven will try reconnect automatically (max 3 times), and if that fails, we show a toast for 5 seconds asking the user to refresh. 

