### PR TITLE
feat: suggest frequently used emojis in quick reactions

### DIFF
--- a/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
@@ -31,7 +31,7 @@ async function search(value: string, maxResults: number = 10): Promise<EmojiType
     return results
 }
 
-function getTopFavoriteEmojis(maxResults: number = 10): EmojiType[] {
+export function getTopFavoriteEmojis(maxResults: number = 10): EmojiType[] {
 
     // ID's of emojis
 

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
@@ -12,8 +12,39 @@ import { toast } from 'sonner'
 import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
 import { CreateThreadActionButton } from './CreateThreadButton'
 import clsx from 'clsx'
+import { EmojiType, getTopFavoriteEmojis } from '../../../ChatInput/EmojiSuggestion'
 
-const QUICK_EMOJIS = ['👍', '✅', '👀', '🎉']
+const topEmojis = getTopFavoriteEmojis(10)
+
+const STANDARD_EMOJIS: EmojiType[] = [{
+    id: '+1',
+    emoji: '👍',
+    name: 'Thumbs Up',
+    shortcodes: ":+1:"
+}, {
+    id: 'white_check_mark',
+    emoji: '✅',
+    name: 'Check Mark Button',
+    shortcodes: ":white_check_mark:"
+},
+{
+    id: 'eyes',
+    emoji: '👀',
+    name: 'Eyes',
+    shortcodes: ":eyes:"
+},
+{
+    id: 'tada',
+    emoji: '🎉',
+    name: 'Party Popper',
+    shortcodes: ":tada:"
+}
+]
+
+// If we have frequently used emojis, then show them, else fill the rest with standard emojis - remove duplicates
+const QUICK_EMOJIS = [...topEmojis, ...STANDARD_EMOJIS].filter((emoji, index, self) =>
+    index === self.findIndex((t) => t.id === emoji.id)
+).slice(0, 4)
 
 interface QuickActionsProps extends MessageContextMenuProps {
     isEmojiPickerOpen: boolean,
@@ -74,17 +105,20 @@ export const QuickActions = ({ message, onReply, onEdit, isEmojiPickerOpen, setI
             )}>
             <Flex gap='1'>
                 {QUICK_EMOJIS.map((emoji) => {
-                    return <QuickActionButton
-                        key={emoji}
-                        className={'text-base'}
-                        tooltip={`React with ${emoji}`}
-                        aria-label={`React with ${emoji}`}
-                        onClick={() => {
-                            onEmojiReact(emoji)
-                        }}>
-                        {/* @ts-expect-error */}
-                        <em-emoji native={emoji} />
-                    </QuickActionButton>
+                    if (emoji.emoji) {
+                        return <QuickActionButton
+                            key={emoji.id}
+                            className={'text-base'}
+                            tooltip={`React with ${emoji.emoji}`}
+                            aria-label={`React with ${emoji.emoji}`}
+                            onClick={() => {
+                                onEmojiReact(emoji.emoji as string)
+                            }}>
+                            {/* @ts-expect-error */}
+                            <em-emoji native={emoji.emoji} />
+                        </QuickActionButton>
+                    }
+                    return null
                 })}
 
                 <EmojiPickerButton


### PR DESCRIPTION
Uses emoji-mart's favourites menu (limited to 4) - does not include any custom emojis (for now). This would be dependent on the browser though, so the suggestions on mobile and web would differ. We probably need to allow this to be user configurable at some point.

![CleanShot 2025-02-19 at 23 34 06@2x](https://github.com/user-attachments/assets/509c39e5-0aaf-4400-beac-94cde5f8e691)

