### PR TITLE
feat: add toggle in sidebar for showing/hiding all channels

### DIFF
--- a/frontend/src/components/feature/channel-groups/UnreadList.tsx
+++ b/frontend/src/components/feature/channel-groups/UnreadList.tsx
@@ -101,7 +101,6 @@ const UnreadSectionActions = ({ channelIDs }: { channelIDs: string[] }) => {
 
     const { mutate } = useSWRConfig()
 
-    const [isOpen, setIsOpen] = useState(false)
     const { call } = useFrappePostCall('raven.api.raven_channel.mark_all_messages_as_read')
     const handleMarkAllAsRead = () => {
         call({
@@ -151,11 +150,10 @@ const UnreadSectionActions = ({ channelIDs }: { channelIDs: string[] }) => {
         }).catch(() => {
             toast.error('Failed to mark all messages as read')
         })
-        setIsOpen(false)
     }
 
     return (
-        <DropdownMenu.Root onOpenChange={(open) => setIsOpen(open)}>
+        <DropdownMenu.Root>
             <DropdownMenu.Trigger>
                 <IconButton
                     aria-label={__("Options")}
@@ -163,15 +161,7 @@ const UnreadSectionActions = ({ channelIDs }: { channelIDs: string[] }) => {
                     variant="soft"
                     size="1"
                     radius="large"
-                    className={clsx(
-                        'cursor-pointer transition-all text-gray-10 dark:text-gray-300 bg-transparent',
-                        'sm:hover:bg-gray-3',
-                        {
-                            'sm:invisible sm:group-hover:visible': !isOpen,
-                            'sm:visible': isOpen, // Ensure it's visible when the dropdown is open
-                        },
-                        'ease-ease',
-                        'outline-none'
+                    className={clsx('transition-all ease-ease text-gray-10 bg-transparent hover:bg-gray-3 hover:text-gray-12'
                     )}>
                     <BiDotsVerticalRounded />
                 </IconButton>

--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -1,9 +1,9 @@
 import { SidebarGroup, SidebarGroupItem, SidebarGroupLabel, SidebarGroupList, SidebarItem } from "../../layout/Sidebar/SidebarComp"
 import { SidebarBadge, SidebarViewMoreButton } from "../../layout/Sidebar/SidebarComp"
 import { CreateChannelButton } from "./CreateChannelModal"
-import { useContext, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { ChannelIcon } from "@/utils/layout/channelIcon"
-import { ContextMenu, Flex, Text } from "@radix-ui/themes"
+import { ContextMenu, DropdownMenu, Flex, IconButton, Text } from "@radix-ui/themes"
 import { useLocation, useParams } from "react-router-dom"
 import { useStickyState } from "@/hooks/useStickyState"
 import useCurrentRavenUser from "@/hooks/useCurrentRavenUser"
@@ -12,6 +12,10 @@ import { FrappeConfig, FrappeContext } from "frappe-react-sdk"
 import { RavenUser } from "@/types/Raven/RavenUser"
 import { __ } from "@/utils/translations"
 import { ChannelWithUnreadCount } from "@/components/layout/Sidebar/useGetChannelUnreadCounts"
+import { useAtom } from "jotai"
+import { showOnlyMyChannelsAtom } from "@/components/layout/Sidebar/SidebarBody"
+import clsx from "clsx"
+import { BiDotsVerticalRounded } from "react-icons/bi"
 
 interface ChannelListProps {
     channels: ChannelWithUnreadCount[]
@@ -48,6 +52,7 @@ export const ChannelList = ({ channels }: ChannelListProps) => {
                     </Flex>
                     <Flex align='center' gap='1'>
                         <CreateChannelButton />
+                        <ChannelListActions />
                         <SidebarViewMoreButton onClick={toggle} expanded={showData} />
                     </Flex>
                 </Flex>
@@ -157,4 +162,38 @@ const PinButton = ({ channelID }: { channelID: string }) => {
         {__("Pin")}
     </ContextMenu.Item>
 
+}
+
+const ChannelListActions = () => {
+
+    const [showOnlyMyChannels, setShowOnlyMyChannels] = useAtom(showOnlyMyChannelsAtom)
+
+    const showAllChannels = useCallback(() => {
+        setShowOnlyMyChannels(false)
+    }, [setShowOnlyMyChannels])
+
+    const hideNonMemberChannels = useCallback(() => {
+        setShowOnlyMyChannels(true)
+    }, [setShowOnlyMyChannels])
+
+    return (
+        <DropdownMenu.Root>
+            <DropdownMenu.Trigger>
+                <IconButton
+                    aria-label={__("Options")}
+                    title={__("Options")}
+                    variant="soft"
+                    size="1"
+                    radius="large"
+                    className={clsx('transition-all ease-ease text-gray-10 bg-transparent hover:bg-gray-3 hover:text-gray-12'
+                    )}>
+                    <BiDotsVerticalRounded />
+                </IconButton>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+                {showOnlyMyChannels ? <DropdownMenu.Item onClick={showAllChannels}>Show All Channels</DropdownMenu.Item> :
+                    <DropdownMenu.Item onClick={hideNonMemberChannels}>Show Only My Channels</DropdownMenu.Item>}
+            </DropdownMenu.Content>
+        </DropdownMenu.Root>
+    )
 }

--- a/frontend/src/components/layout/Sidebar/SidebarBody.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarBody.tsx
@@ -11,6 +11,9 @@ import { UnreadList } from '@/components/feature/channel-groups/UnreadList'
 import { ChannelListContext, ChannelListContextType } from '@/utils/channel/ChannelListProvider'
 import { useGetChannelUnreadCounts } from './useGetChannelUnreadCounts'
 import { useParams } from 'react-router-dom'
+import { atomWithStorage } from 'jotai/utils'
+
+export const showOnlyMyChannelsAtom = atomWithStorage('showOnlyMyChannels', false)
 
 export const SidebarBody = () => {
 
@@ -43,8 +46,8 @@ export const SidebarBody = () => {
                         label='Saved'
                         icon={<BiBookmark className='text-gray-12 dark:text-gray-300 mt-0.5 sm:text-sm text-base' />}
                         iconLabel='Saved Message' />
-                    <PinnedChannels unread_count={unread_count?.message} />
                 </Flex>
+                <PinnedChannels unread_count={unread_count?.message} />
                 {(unreadChannels.length > 0 || unreadDMs.length > 0) && <UnreadList unreadChannels={unreadChannels} unreadDMs={unreadDMs} />}
                 <ChannelList channels={readChannels} />
                 <DirectMessageList dm_channels={readDMs} />

--- a/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
+++ b/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
@@ -1,5 +1,7 @@
 import { ChannelListItem, DMChannelListItem, UnreadCountData } from '@/utils/channel/ChannelListProvider';
+import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
+import { showOnlyMyChannelsAtom } from './SidebarBody';
 
 export interface UseGetChannelUnreadCountProps {
     channels: ChannelListItem[]
@@ -16,6 +18,8 @@ export interface DMChannelWithUnreadCount extends DMChannelListItem {
 }
 
 export const useGetChannelUnreadCounts = ({ channels, dm_channels, unread_count }: UseGetChannelUnreadCountProps) => {
+
+    const showOnlyMyChannels = useAtomValue(showOnlyMyChannelsAtom)
 
     const { unreadChannels, readChannels, unreadDMs, readDMs } = useMemo(() => {
 
@@ -34,36 +38,53 @@ export const useGetChannelUnreadCounts = ({ channels, dm_channels, unread_count 
         const allChannels: (ChannelListItem | DMChannelListItem)[] = [...channels, ...dm_channels]
 
         // Process all channels and DMs to separate unread and read
-        allChannels.filter((channel) => {
+        allChannels.forEach(channel => {
+
             if (channel.is_archived) {
-                return false
+                // If the channel is archived, do not add to array
+                return
             }
-            if (channel.type === "Public" && !channel.member_id) {
-                return false
-            }
-            return true
-        }).forEach(channel => {
             const unreadCount = unreadCounts[channel.name] || 0
             const channelWithUnread = { ...channel, unread_count: unreadCount }
 
             if (unreadCount > 0) {
+                // If the channel has unread messages
                 if ('is_direct_message' in channel && channel.is_direct_message) {
+                    // If it is a DM channel, add to unreadDMs
                     unreadDMs.push(channelWithUnread as DMChannelWithUnreadCount)
                 } else {
-                    unreadChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                    // Else it's a regular channel
+                    // For channels that are public but the user is not a member, do not add to unread channel array
+                    if (channel.type === "Public" && !channel.member_id) {
+                        if (!showOnlyMyChannels) {
+                            // Instead add to readChannels if showOnlyMyChannels is false
+                            readChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                        }
+                    } else {
+                        unreadChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                    }
+
                 }
             } else {
                 if ('is_direct_message' in channel && channel.is_direct_message) {
                     readDMs.push(channelWithUnread as DMChannelWithUnreadCount)
                 } else {
-                    readChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                    console.log(channel.member_id, showOnlyMyChannels)
+                    let shouldAddToReadChannels = true
+
+                    if (showOnlyMyChannels && !channel.member_id) {
+                        shouldAddToReadChannels = false
+                    }
+                    if (shouldAddToReadChannels) {
+                        readChannels.push(channelWithUnread as ChannelWithUnreadCount)
+                    }
                 }
             }
         });
 
         return { unreadChannels, readChannels, unreadDMs, readDMs }
 
-    }, [channels, dm_channels, unread_count])
+    }, [channels, dm_channels, unread_count, showOnlyMyChannels])
 
     return { unreadChannels, readChannels, unreadDMs, readDMs }
 }


### PR DESCRIPTION
Users can now choose if they wish to see all channels (including public channels that they are not a member of) or just their own channels. This is persisted in local storage.

Unread counts for channels where they are not a member of is not shown (neither fetched)



https://github.com/user-attachments/assets/e3c095dc-4e81-4f1e-983f-d2d4cf0d2f41

