### PR TITLE
perf: optimistic updates for reactions

### DIFF
--- a/frontend/src/components/feature/chat/ChatMessage/LeftRightLayout/LeftRightLayout.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/LeftRightLayout/LeftRightLayout.tsx
@@ -127,7 +127,7 @@ export const LeftRightLayout = ({ message, user, isActive, isHighlighted, onRepl
 
                                 {message_reactions?.length &&
                                     <MessageReactions
-                                        messageID={name}
+                                        message={message}
                                         message_reactions={message_reactions}
                                     />
                                 }

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/QuickActions/QuickActions.tsx
@@ -3,7 +3,6 @@ import { MessageContextMenuProps } from '../MessageActions'
 import { QUICK_ACTION_BUTTON_CLASS, QuickActionButton } from './QuickActionButton'
 import { BiDotsHorizontalRounded } from 'react-icons/bi'
 import { MouseEventHandler, useContext, useRef } from 'react'
-import { FrappeConfig, FrappeContext } from 'frappe-react-sdk'
 import { EmojiPickerButton } from './EmojiPickerButton'
 import { UserContext } from '@/utils/auth/UserProvider'
 import { AiOutlineEdit } from 'react-icons/ai'
@@ -13,6 +12,7 @@ import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
 import { CreateThreadActionButton } from './CreateThreadButton'
 import clsx from 'clsx'
 import { EmojiType, getTopFavoriteEmojis } from '../../../ChatInput/EmojiSuggestion'
+import usePostMessageReaction from '@/hooks/usePostMessageReaction'
 
 const topEmojis = getTopFavoriteEmojis(10)
 
@@ -59,8 +59,6 @@ export const QuickActions = ({ message, onReply, onEdit, isEmojiPickerOpen, setI
     const isOwner = currentUser === message?.owner && !message?.is_bot_message
     const toolbarRef = useRef<HTMLDivElement>(null)
 
-    const { call } = useContext(FrappeContext) as FrappeConfig
-
     /**
      * When the user clicks on the more button, we want to trigger a right click event
      * so that we open the context menu instead of duplicating the actions in a dropdown menu
@@ -81,17 +79,16 @@ export const QuickActions = ({ message, onReply, onEdit, isEmojiPickerOpen, setI
         e.target.dispatchEvent(evt);
     }
 
+    const postReaction = usePostMessageReaction()
+
     const onEmojiReact = (emoji: string, is_custom: boolean = false, emoji_name?: string) => {
-        call.post('raven.api.reactions.react', {
-            message_id: message?.name,
-            reaction: emoji,
-            is_custom,
-            emoji_name
-        }).catch((err) => {
-            toast.error("Could not react to message.", {
-                description: getErrorMessage(err)
+        if (message) {
+            postReaction(message, emoji, is_custom, emoji_name).catch((err) => {
+                toast.error("Could not react to message.", {
+                    description: getErrorMessage(err)
+                })
             })
-        })
+        }
     }
 
     // @ts-ignore

--- a/frontend/src/components/feature/chat/ChatMessage/MessageItem.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageItem.tsx
@@ -201,7 +201,7 @@ export const MessageItem = ({ message, setDeleteMessage, isHighlighted, onReplyM
                                     {message.is_edited === 1 && <Text size='1' className='text-gray-10'>(edited)</Text>}
                                     {message_reactions?.length &&
                                         <MessageReactions
-                                            messageID={name}
+                                            message={message}
                                             message_reactions={message_reactions}
                                         />
                                     }

--- a/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
@@ -6,6 +6,8 @@ import { useGetUserRecords } from "@/hooks/useGetUserRecords"
 import { Flex, Text, Tooltip } from "@radix-ui/themes"
 import { clsx } from "clsx"
 import { EmojiPickerButton } from "./MessageActions/QuickActions/EmojiPickerButton"
+import usePostMessageReaction from "@/hooks/usePostMessageReaction"
+import { Message } from "../../../../../../types/Messaging/Message"
 
 export interface ReactionObject {
     // The emoji
@@ -19,22 +21,17 @@ export interface ReactionObject {
     // The name of the custom emoji
     emoji_name: string
 }
-export const MessageReactions = ({ messageID, message_reactions }: { messageID: string, message_reactions?: string | null }) => {
+export const MessageReactions = ({ message, message_reactions }: { message: Message, message_reactions?: string | null }) => {
 
     const { currentUser } = useContext(UserContext)
 
-    const { call: reactToMessage } = useFrappePostCall('raven.api.reactions.react')
+    const postReaction = usePostMessageReaction()
 
     const saveReaction = useCallback((emoji: string, is_custom: boolean = false, emoji_name?: string) => {
-        if (messageID) {
-            return reactToMessage({
-                message_id: messageID,
-                reaction: emoji,
-                is_custom,
-                emoji_name
-            })
+        if (message) {
+            postReaction(message, emoji, is_custom, emoji_name)
         }
-    }, [messageID, reactToMessage])
+    }, [message])
 
     const allUsers = useGetUserRecords()
     const reactions: ReactionObject[] = useMemo(() => {
@@ -107,9 +104,9 @@ const ReactionButton = ({ reaction, onReactionClick, currentUser, allUsers }: Re
     }, [allUsers, count, currentUser, reaction, users])
 
     return (
-        <Tooltip content={<p className="my-0 max-w-96">
+        <Tooltip content={<span className="my-0 max-w-96">
             {label}
-        </p>}>
+        </span>}>
             <button
                 onClick={onClick}
                 className={clsx("w-fit sm:h-full text-xs py-0.5 cursor-pointer rounded-md min-w-[4ch] border font-semibold",

--- a/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageReactions.tsx
@@ -8,6 +8,8 @@ import { clsx } from "clsx"
 import { EmojiPickerButton } from "./MessageActions/QuickActions/EmojiPickerButton"
 import usePostMessageReaction from "@/hooks/usePostMessageReaction"
 import { Message } from "../../../../../../types/Messaging/Message"
+import { toast } from "sonner"
+import { getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
 
 export interface ReactionObject {
     // The emoji
@@ -30,6 +32,11 @@ export const MessageReactions = ({ message, message_reactions }: { message: Mess
     const saveReaction = useCallback((emoji: string, is_custom: boolean = false, emoji_name?: string) => {
         if (message) {
             postReaction(message, emoji, is_custom, emoji_name)
+                .catch((err) => {
+                    toast.error("Could not react to message.", {
+                        description: getErrorMessage(err)
+                    })
+                })
         }
     }, [message])
 

--- a/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
+++ b/frontend/src/components/layout/Sidebar/useGetChannelUnreadCounts.ts
@@ -69,7 +69,6 @@ export const useGetChannelUnreadCounts = ({ channels, dm_channels, unread_count 
                 if ('is_direct_message' in channel && channel.is_direct_message) {
                     readDMs.push(channelWithUnread as DMChannelWithUnreadCount)
                 } else {
-                    console.log(channel.member_id, showOnlyMyChannels)
                     let shouldAddToReadChannels = true
 
                     if (showOnlyMyChannels && !channel.member_id) {

--- a/frontend/src/hooks/usePostMessageReaction.ts
+++ b/frontend/src/hooks/usePostMessageReaction.ts
@@ -1,0 +1,96 @@
+import { FrappeConfig, FrappeContext, useSWRConfig } from 'frappe-react-sdk'
+import { useCallback, useContext } from 'react'
+import { Message } from '../../../types/Messaging/Message'
+import { GetMessagesResponse } from '@/components/feature/chat/ChatStream/useChatStream'
+import { ReactionObject } from '@/components/feature/chat/ChatMessage/MessageReactions'
+import { useUserData } from './useUserData'
+
+/**
+ * This hook is used to post a reaction to a message optimistically
+ * @returns A function to post a reaction to a message
+ */
+const usePostMessageReaction = () => {
+
+    const { call } = useContext(FrappeContext) as FrappeConfig
+
+    const { mutate } = useSWRConfig()
+
+    const { name: username } = useUserData()
+
+    const postReaction = useCallback((message: Message, emoji: string, is_custom: boolean = false, emoji_name?: string) => {
+
+        const updateMessageWithReaction = (data?: GetMessagesResponse) => {
+            const existingMessages = data?.message.messages ?? []
+
+            // Find the message with the ID and update it's reactions object
+            const newMessages = existingMessages.map(m => {
+                if (m.name !== message.name) {
+                    return m
+                }
+
+                // If the message ID matches, we need to update the reactions object
+                const existingReactions = JSON.parse(m.message_reactions ?? '{}') as Record<string, ReactionObject>
+
+                // Check if the emoji is already in the reactions object
+                if (existingReactions[emoji]) {
+                    // If it is, check how many users have reacted to the message
+                    const userCount = existingReactions[emoji].count
+
+                    // If the user has already reacted, remove their reaction
+                    if (userCount > 1) {
+                        existingReactions[emoji].users = existingReactions[emoji].users.filter(u => u !== username)
+                        existingReactions[emoji].count = existingReactions[emoji].count - 1
+                    } else {
+                        // If there is only one user, remove the reaction
+                        delete existingReactions[emoji]
+                    }
+                } else {
+                    // If it's not, add it
+                    existingReactions[emoji] = {
+                        reaction: emoji,
+                        users: [username],
+                        count: 1,
+                        emoji_name: emoji_name ?? ''
+                    }
+                }
+                return {
+                    ...m,
+                    message_reactions: JSON.stringify(existingReactions)
+                }
+
+            })
+
+            return {
+                message: {
+                    has_new_messages: data?.message.has_new_messages ?? false,
+                    has_old_messages: data?.message.has_old_messages ?? true,
+                    messages: newMessages
+                }
+            }
+
+        }
+
+        return mutate({ path: `get_messages_for_channel_${message.channel_id}` }, async (data?: GetMessagesResponse) => {
+
+            // Make the request
+            return call.post('raven.api.reactions.react', {
+                message_id: message.name,
+                reaction: emoji,
+                is_custom,
+                emoji_name
+            }).then(() => {
+                return updateMessageWithReaction(data)
+            })
+        }, {
+            optimisticData: (data?: GetMessagesResponse) => {
+                return updateMessageWithReaction(data)
+            },
+            rollbackOnError: true,
+            revalidate: false
+        })
+    }, [])
+
+    return postReaction
+}
+
+export default usePostMessageReaction


### PR DESCRIPTION
On reacting to a message, raven will first update the cache optimistically, then wait for the response from the server and if the response is Ok, it will update the message in the cache. If the response is an error, it will rollback.

Post this, when the websocket event comes in for the reaction, the message will be updated anyway, so if there are multiple people reacting, it will reflect the correct value