### PR TITLE
fix: janky scroll in chat stream when content loads

### DIFF
--- a/frontend/src/components/feature/GlobalSearch/MessageSearch.tsx
+++ b/frontend/src/components/feature/GlobalSearch/MessageSearch.tsx
@@ -43,17 +43,21 @@ export const MessageSearch = ({ onToggleMyChannels, isOnlyInMyChannels, onToggle
 
     const navigate = useNavigate()
 
-    const handleNavigateToChannel = (channelID: string, baseMessage?: string) => {
+    const handleNavigateToChannel = (channelID: string, baseMessage?: string, workspace?: string) => {
         onClose()
-        navigate(`/channel/${channelID}`, {
+        let path = `/channel/${channelID}`
+        if (workspace) {
+            path = `/${workspace}/${channelID}`
+        }
+        navigate(path, {
             state: {
                 baseMessage
             }
         })
     }
 
-    const handleScrollToMessage = async (messageName: string, channelID: string) => {
-        handleNavigateToChannel(channelID, messageName)
+    const handleScrollToMessage = async (messageName: string, channelID: string, workspace?: string) => {
+        handleNavigateToChannel(channelID, messageName, workspace)
     }
 
     const users = useGetUserRecords()

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageActions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageActions.tsx
@@ -133,7 +133,7 @@ export const MessageContextMenu = ({ message, onDelete, onEdit, onReply, onForwa
 const SaveMessageAction = ({ message }: { message: Message }) => {
 
     const { currentUser } = useContext(UserContext)
-    const isSaved = JSON.parse(message._liked_by ?? '[]').includes(currentUser)
+    const isSaved = JSON.parse(message._liked_by ? message._liked_by : '[]').includes(currentUser)
 
     const { call } = useContext(FrappeContext) as FrappeConfig
 

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/LinkPreview.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/TiptapRenderer/LinkPreview.tsx
@@ -72,14 +72,10 @@ const LinkPreview = memo(({ messageID }: { messageID: string }) => {
 
     return <WebLinkPreview href={href} messageID={messageID} />
 
-
-
-    return null
-
 })
 
 const WebLinkPreview = ({ href, messageID }: { href: string, messageID: string }) => {
-    const { data } = useFrappeGetCall<{ message: LinkPreviewDetails[] }>('raven.api.preview_links.get_preview_link', {
+    const { data, isLoading } = useFrappeGetCall<{ message: LinkPreviewDetails[] }>('raven.api.preview_links.get_preview_link', {
         urls: JSON.stringify([href])
     }, href ? `link_preview_${href}` : null, {
         revalidateOnFocus: false,
@@ -97,7 +93,9 @@ const WebLinkPreview = ({ href, messageID }: { href: string, messageID: string }
 
     const linkPreview = data?.message?.[0]
 
-    if (!href || !linkPreview) return null
+    if (isLoading) {
+        return <SkeletonWebLinkPreview />
+    }
 
     if (linkPreview && linkPreview.site_name && linkPreview.description) {
 
@@ -144,6 +142,31 @@ const WebLinkPreview = ({ href, messageID }: { href: string, messageID: string }
     }
 
     return null
+}
+
+const SkeletonWebLinkPreview = () => {
+    return <Box pt='2' maxWidth={{
+        md: '580px',
+    }} className='sm:max-w-[580px] max-w-[356px]'>
+        <Card asChild className='p-0 sm:p-3'>
+            <div className='animate-pulse flex sm:items-center flex-col sm:flex-row sm:gap-4 gap-0'>
+                {/* Image skeleton */}
+                <div className="sm:max-w-[220px] w-full h-[160px] sm:h-[120px] bg-gray-200 sm:-ml-3 sm:-mt-3 sm:-mb-3" />
+                {/* Content skeleton */}
+                <Stack className='gap-1.5 sm:p-0 py-3 px-3 flex-1'>
+                    <Stack className='sm:gap-1 gap-0.5'>
+                        <div className="h-5 bg-gray-200 rounded w-3/4" />
+                        <div className="h-4 bg-gray-200 rounded w-1/3" />
+                    </Stack>
+                    <div className="space-y-1.5">
+                        <div className="h-3 bg-gray-200 rounded w-full" />
+                        <div className="h-3 bg-gray-200 rounded w-full" />
+                        <div className="h-3 bg-gray-200 rounded w-2/3" />
+                    </div>
+                </Stack>
+            </div>
+        </Card>
+    </Box>
 }
 
 const YOUTUBE_REGEX = /^((?:https?:)?\/\/)?((?:www|m|music)\.)?((?:youtube\.com|youtu.be|youtube-nocookie\.com))(\/(?:[\w-]+\?v=|embed\/|v\/)?)([\w-]+)(\S+)?$/

--- a/frontend/src/components/feature/chat/ChatStream/useChatStream.ts
+++ b/frontend/src/components/feature/chat/ChatStream/useChatStream.ts
@@ -93,7 +93,6 @@ const useChatStream = (channelID: string, scrollRef: MutableRefObject<HTMLDivEle
      * Need to scroll down twice because the scrollHeight is not updated immediately after the first scroll
      */
     useLayoutEffect(() => {
-        // if (done) {
 
         setTimeout(() => {
             scrollRef.current?.scroll({
@@ -111,7 +110,6 @@ const useChatStream = (channelID: string, scrollRef: MutableRefObject<HTMLDivEle
 
 
         scrollRef.current?.scrollTo(0, scrollRef.current?.scrollHeight)
-        // }
     }, [done, channelID])
 
 
@@ -442,11 +440,12 @@ const useChatStream = (channelID: string, scrollRef: MutableRefObject<HTMLDivEle
                 let currentDate = messages[messages.length - 1].creation.split(' ')[0]
                 let currentDateTime = new Date(messages[messages.length - 1].creation.split('.')[0]).getTime()
 
-                messagesWithDateSeparators.push({
-                    creation: getDateObject(`${currentDate} 00:00:00`).format('Do MMMM YYYY'),
-                    message_type: 'date',
-                    name: currentDate
-                })
+                // Do not add the date separator to the oldest message since we don't know if it's the first message of the day
+                // messagesWithDateSeparators.push({
+                //     creation: getDateObject(`${currentDate} 00:00:00`).format('Do MMMM YYYY'),
+                //     message_type: 'date',
+                //     name: currentDate
+                // })
 
                 messagesWithDateSeparators.push({
                     ...messages[messages.length - 1],

--- a/raven/api/search.py
+++ b/raven/api/search.py
@@ -70,6 +70,7 @@ def get_search_result(
 			message.channel_id,
 			message.text,
 			message.content,
+			channel.workspace,
 		)
 		.join(channel, JoinType.left)
 		.on(message.channel_id == channel.name)


### PR DESCRIPTION
Added a skeleton loader for link previews of similar height - this was the primary cause of the janky scroll since the content loaded after the messages were rendered.

Also added a resize observer to the main container - if the user is within 100px of the bottom, we automatically scroll to the bottom if the content resizes.

When loading older messages, we were earlier restoring the scroll position by scrolling to the last message. This has been made much smoother - we now restore the last scroll position instead

Closes #1158 
