### PR TITLE
fix: allow user and channel mentions without preceding space

### DIFF
--- a/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/EmojiSuggestion.tsx
@@ -74,6 +74,8 @@ export const EmojiSuggestion = Node.create({
             Suggestion({
                 editor: this.editor,
                 char: ':',
+                // Allow any character to be a prefix for an emoji
+                allowedPrefixes: null,
                 items: (query) => {
                     if (query.query.length !== 0) {
                         return search(query.query)

--- a/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
+++ b/frontend/src/components/feature/chat/ChatInput/Tiptap.tsx
@@ -76,6 +76,13 @@ export const UserMention = Mention.extend({
         suggestion: {
             char: '@',
             pluginKey: new PluginKey('userMention'),
+            // Allow any character to be a prefix for a user mention
+            allowedPrefixes: null,
+            allow: (props) => {
+                // Do not allow mentions if the preceding character is a letter or digit
+                const precedingCharacter = props.state.doc.textBetween(props.range.from - 1, props.range.from, '')
+                return !/[a-zA-Z0-9]/.test(precedingCharacter)
+            }
         }
     })
 
@@ -86,6 +93,13 @@ export const ChannelMention = Mention.extend({
         suggestion: {
             char: '#',
             pluginKey: new PluginKey('channelMention'),
+            // Allow any character to be a prefix for a channel mention
+            allowedPrefixes: null,
+            allow: (props) => {
+                // Do not allow mentions if the preceding character is a letter or digit
+                const precedingCharacter = props.state.doc.textBetween(props.range.from - 1, props.range.from, '')
+                return !/[a-zA-Z0-9]/.test(precedingCharacter)
+            }
         }
     })
 


### PR DESCRIPTION
For emojis: allow any preceding character
For user and channel mentions - allow any preceding character except a letter a digit since users would type in emails etc. Brackets, hyphens etc would work.

Reference: https://tiptap.dev/docs/editor/api/utilities/suggestion#allow