### PR TITLE
fix: remove html tags in doctype link renderer

### DIFF
--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -197,7 +197,7 @@ const DoctypeCard = ({ data, doctype, route, docname, mutate }: {
                                     {item}
                                 </DataList.Label>
                                 <DataList.Value>
-                                    {data[item]}
+                                    {typeof data[item] === 'string' ? data[item].replace(/<[^>]*>/g, '') : data[item]}
                                 </DataList.Value>
                             </DataList.Item>
                         ))

--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/DoctypeLinkRenderer.tsx
@@ -8,7 +8,7 @@ import { BiCopy, BiDotsHorizontalRounded, BiGitPullRequest, BiLinkExternal, BiPr
 import useDoctypeMeta from "@/hooks/useDoctypeMeta"
 import { HStack } from "@/components/layout/Stack"
 import { ErrorBanner, getErrorMessage } from "@/components/layout/AlertBanner/ErrorBanner"
-
+import parse from 'html-react-parser';
 
 export const DoctypeLinkRenderer = ({ doctype, docname }: { doctype: string, docname: string }) => {
 
@@ -197,7 +197,7 @@ const DoctypeCard = ({ data, doctype, route, docname, mutate }: {
                                     {item}
                                 </DataList.Label>
                                 <DataList.Value>
-                                    {typeof data[item] === 'string' ? data[item].replace(/<[^>]*>/g, '') : data[item]}
+                                    {parse(data[item] ?? '')}
                                 </DataList.Value>
                             </DataList.Item>
                         ))


### PR DESCRIPTION
Description:
Sanitize HTML content before rendering it in Doctype link message

Output:
before
<img width="1112" alt="Screenshot 2025-02-27 at 3 43 56 PM" src="https://github.com/user-attachments/assets/bc52eb83-055e-44bc-851c-df35a467644c" />

after
![screenshot](https://github.com/user-attachments/assets/da68bd50-9c3a-457e-a337-f85203245968)


