### PR TITLE
perf: cache number of thread replies

### DIFF
--- a/frontend/src/components/feature/chat/ChatMessage/Renderers/ThreadMessage.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/Renderers/ThreadMessage.tsx
@@ -1,10 +1,7 @@
 import { Link, useParams } from "react-router-dom"
 import { Message } from "../../../../../../../types/Messaging/Message"
 import { Button, Flex, Text } from "@radix-ui/themes"
-import { useFrappeGetDocCount } from "frappe-react-sdk"
-import { RavenMessage } from "@/types/RavenMessaging/RavenMessage"
-import { useFrappeDocumentEventListener } from "frappe-react-sdk"
-import { useFrappeEventListener } from "frappe-react-sdk"
+import { useFrappeGetCall } from "frappe-react-sdk"
 
 export const ThreadMessage = ({ thread }: { thread: Message }) => {
 
@@ -28,21 +25,15 @@ export const ThreadMessage = ({ thread }: { thread: Message }) => {
 
 export const ThreadReplyCount = ({ thread }: { thread: Message }) => {
 
-    const { data, mutate } = useFrappeGetDocCount<RavenMessage>("Raven Message", [["channel_id", "=", thread.name], ["message_type", "!=", "System"]], undefined, undefined, undefined, {
+    const { data } = useFrappeGetCall<{ message: number }>("raven.api.threads.get_number_of_replies", {
+        thread_id: thread.name
+    }, ["thread_reply_count", thread.name], {
         revalidateOnFocus: false,
-        shouldRetryOnError: false,
-        keepPreviousData: false
-    })
-
-    // Listen to realtime event for new message count
-    useFrappeDocumentEventListener('Raven Message', thread.name, () => { })
-
-    useFrappeEventListener('thread_reply_created', () => {
-        mutate()
+        shouldRetryOnError: false
     })
 
     return <Flex gap='1' align={'center'}>
-        <Text size='1' className={'font-semibold text-accent-a11'}>{data ?? 0}</Text>
-        <Text size='1' className={'font-semibold text-accent-a11'}>{data && data === 1 ? 'Reply' : 'Replies'}</Text>
+        <Text size='1' className={'font-semibold text-accent-a11'}>{data?.message ?? 0}</Text>
+        <Text size='1' className={'font-semibold text-accent-a11'}>{data?.message === 1 ? 'Reply' : 'Replies'}</Text>
     </Flex>
 }

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -56,6 +56,15 @@ const MainPageContent = () => {
         mutate(["channel_members", payload.channel_id])
     })
 
+    // Listen to realtime event for new message count
+    useFrappeEventListener('thread_reply', (event) => {
+        mutate(["thread_reply_count", event.channel_id], {
+            message: event.number_of_replies
+        }, {
+            revalidate: false
+        })
+    })
+
     return <UserListProvider>
         <ChannelListProvider>
             <Flex>

--- a/raven/api/threads.py
+++ b/raven/api/threads.py
@@ -4,10 +4,18 @@ from frappe.query_builder import Order
 from frappe.query_builder.functions import Coalesce, Count
 
 from raven.api.raven_channel import get_peer_user_id
-from raven.utils import get_channel_members
+from raven.utils import get_channel_members, get_thread_reply_count
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
+def get_number_of_replies(thread_id: str):
+	"""
+	Get the number of replies in a thread
+	"""
+	return get_thread_reply_count(thread_id)
+
+
+@frappe.whitelist(methods=["GET"])
 def get_all_threads(
 	workspace: str = None, content=None, channel_id=None, is_ai_thread=0, start_after=0, limit=10
 ):
@@ -90,7 +98,7 @@ def get_all_threads(
 	return threads
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_other_threads(
 	workspace: str = None, content=None, channel_id=None, is_ai_thread=0, start_after=0, limit=10
 ):
@@ -98,7 +106,6 @@ def get_other_threads(
 	Get all the threads in which the user is not a participant, but is a member of the channel
 	"""
 
-	channel = frappe.qb.DocType("Raven Channel")
 	channel_member = frappe.qb.DocType("Raven Channel Member")
 	thread_channel = frappe.qb.DocType("Raven Channel").as_("thread_channel")
 	main_thread_message = frappe.qb.DocType("Raven Message").as_("main_thread_message")
@@ -178,7 +185,7 @@ def get_other_threads(
 	return threads
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["GET"])
 def get_unread_threads(workspace: str = None):
 	"""
 	Get the number of threads in which the user is a participant and has unread messages > 0
@@ -210,7 +217,7 @@ def get_unread_threads(workspace: str = None):
 	return query.run(as_dict=True)
 
 
-@frappe.whitelist(methods="POST")
+@frappe.whitelist(methods=["POST"])
 def create_thread(message_id):
 	"""
 	A thread can be created by any user with read access to the channel in which the message has been sent.

--- a/raven/utils.py
+++ b/raven/utils.py
@@ -166,3 +166,21 @@ def get_raven_user(user_id: str) -> str:
 	"""
 	# TODO: Run this via cache
 	return frappe.db.get_value("Raven User", {"user": user_id}, "name")
+
+
+def get_thread_reply_count(thread_id: str) -> int:
+	"""
+	Get the number of replies in a thread
+	"""
+	return frappe.cache().hget(
+		"raven:thread_reply_count",
+		thread_id,
+		lambda: frappe.db.count("Raven Message", {"channel_id": thread_id}),
+	)
+
+
+def clear_thread_reply_count_cache(thread_id: str):
+	"""
+	Clear the thread reply count cache
+	"""
+	frappe.cache().hdel("raven:thread_reply_count", thread_id)


### PR DESCRIPTION
### Earlier

If a thread message came up on the main channel's chat stream, we used to:
1. Fetch the number of replies using the `frappe.client.get_count` API without caching since it was using a filter.
2. Subscribe to the "Raven Message" document - this would then lead to permission checks etc
3. Anytime a new thread reply came in, we called the same API.

If there were a 100 users on a channel, they would all independently fetch the count + subscribe to the Raven Message + then if a new message came in, all of them would fetch the count again.
Yes, I know.

### Now
If a thread message is on the main channel's chat stream:
1. Fetch the number of replies - cached in the backend as well.
2. No subscription to Raven Message
3. Anytime a new thread reply came in, the websocket event has the new reply count and we update the local cache without making any additional API call
