### PR TITLE
feat: shareable message links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           check-latest: true
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}

--- a/frontend/src/components/feature/GlobalSearch/MessageSearch.tsx
+++ b/frontend/src/components/feature/GlobalSearch/MessageSearch.tsx
@@ -49,10 +49,9 @@ export const MessageSearch = ({ onToggleMyChannels, isOnlyInMyChannels, onToggle
         if (workspace) {
             path = `/${workspace}/${channelID}`
         }
-        navigate(path, {
-            state: {
-                baseMessage
-            }
+        navigate({
+            pathname: path,
+            search: `message_id=${baseMessage}`
         })
     }
 

--- a/frontend/src/components/feature/channels/ChannelList.tsx
+++ b/frontend/src/components/feature/channels/ChannelList.tsx
@@ -4,7 +4,7 @@ import { CreateChannelButton } from "./CreateChannelModal"
 import { useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { ChannelIcon } from "@/utils/layout/channelIcon"
 import { ContextMenu, DropdownMenu, Flex, IconButton, Text } from "@radix-ui/themes"
-import { useLocation, useParams } from "react-router-dom"
+import { useParams, useSearchParams } from "react-router-dom"
 import { useStickyState } from "@/hooks/useStickyState"
 import useCurrentRavenUser from "@/hooks/useCurrentRavenUser"
 import { RiPushpinLine, RiUnpinLine } from "react-icons/ri"
@@ -83,13 +83,13 @@ export const ChannelItemElement = ({ channel }: { channel: ChannelWithUnreadCoun
 
     const { channelID } = useParams()
 
-    const { state } = useLocation()
+    const [searchParams] = useSearchParams()
 
     /**
      * Show the unread count if it exists and either the channel is not the current channel,
      * or if it is the current channel, the user is viewing a base message
      */
-    const showUnread = channel.unread_count && (channelID !== channel.name || state?.baseMessage)
+    const showUnread = channel.unread_count && (channelID !== channel.name || searchParams.get('message_id'))
 
     return (
         <ContextMenu.Root>

--- a/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageActions.tsx
+++ b/frontend/src/components/feature/chat/ChatMessage/MessageActions/MessageActions.tsx
@@ -9,11 +9,12 @@ import { RetractVote } from './RetractVote'
 import { toast } from 'sonner'
 import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
 import { AiOutlineEdit } from 'react-icons/ai'
-import { LuForward, LuReply } from 'react-icons/lu'
+import { LuForward, LuLink, LuReply } from 'react-icons/lu'
 import { MdOutlineEmojiEmotions } from "react-icons/md";
 import { CreateThreadContextItem } from './QuickActions/CreateThreadButton'
 import { RiPushpinLine, RiUnpinLine } from 'react-icons/ri'
 import MessageActionSubMenu from './MessageActionSubMenu'
+import { useParams } from 'react-router-dom'
 
 export interface MessageContextMenuProps {
     message?: Message | null,
@@ -29,6 +30,8 @@ export const MessageContextMenu = ({ message, onDelete, onEdit, onReply, onForwa
 
     const copy = useMessageCopy(message)
     const { currentUser } = useContext(UserContext)
+
+    const { workspaceID } = useParams()
 
     const isOwner = currentUser === message?.owner && !message?.is_bot_message
 
@@ -46,6 +49,7 @@ export const MessageContextMenu = ({ message, onDelete, onEdit, onReply, onForwa
                         Reply
                     </Flex>
                 </ContextMenu.Item>
+
                 <ContextMenu.Item>
                     <Flex gap='2' width='100%' onClick={onForward}>
                         <LuForward size='18' />
@@ -53,6 +57,7 @@ export const MessageContextMenu = ({ message, onDelete, onEdit, onReply, onForwa
                     </Flex>
                 </ContextMenu.Item>
                 {message && !message.is_thread && showThreadButton && <CreateThreadContextItem messageID={message.name} />}
+                <CopyMessageLink message={message} />
                 <ContextMenu.Separator />
                 <ContextMenu.Group>
                     {message.message_type === 'Text' &&
@@ -128,6 +133,29 @@ export const MessageContextMenu = ({ message, onDelete, onEdit, onReply, onForwa
             </> : null}
         </ContextMenu.Content>
     )
+}
+
+const CopyMessageLink = ({ message }: { message: Message }) => {
+    const { workspaceID, threadID } = useParams()
+
+    const onClick = () => {
+        const basePath = `${import.meta.env.VITE_BASE_NAME}`
+
+        const isMessageInThread = threadID === message.channel_id
+        if (isMessageInThread) {
+            navigator.clipboard.writeText(`${window.location.origin}${basePath}/${workspaceID}/threads/${threadID}?message_id=${message.name}`)
+        } else {
+            navigator.clipboard.writeText(`${window.location.origin}${basePath}/${workspaceID}/${message.channel_id}?message_id=${message.name}`)
+        }
+        toast.success('Message link copied to clipboard')
+    }
+
+    return <ContextMenu.Item>
+        <Flex gap='2' width='100%' onClick={onClick}>
+            <BiLink size='18' />
+            Copy Message Link
+        </Flex>
+    </ContextMenu.Item>
 }
 
 const SaveMessageAction = ({ message }: { message: Message }) => {

--- a/frontend/src/components/feature/message-actions/MessageActionVariableBuilder.tsx
+++ b/frontend/src/components/feature/message-actions/MessageActionVariableBuilder.tsx
@@ -448,7 +448,10 @@ const FieldForm = ({ doctype, field, onAdd }: { doctype?: string, field?: RavenM
                                             <Select.Item value='creation'>Creation (Datetime)</Select.Item>
                                             <Select.Item value='message_type'>Message Type</Select.Item>
                                             <Select.Item value='link_doctype'>Linked DocType</Select.Item>
-                                            <Select.Item value='link_document'>Link Document</Select.Item>
+                                            <Select.Item value='link_document'>Linked Document</Select.Item>
+                                            <Select.Item value='channel_id'>Channel ID</Select.Item>
+                                            <Select.Item value='workspace_id'>Workspace ID</Select.Item>
+                                            <Select.Item value='message_url'>Message URL</Select.Item>
                                         </Select.Content>
                                     </Select.Root>
 

--- a/frontend/src/components/feature/saved-messages/SavedMessages.tsx
+++ b/frontend/src/components/feature/saved-messages/SavedMessages.tsx
@@ -26,10 +26,10 @@ const SavedMessages = () => {
         } else {
             baseRoute = `/${workspaceID}`
         }
-        navigate(`${baseRoute}/${channelID}`, {
-            state: {
-                baseMessage: baseMessage
-            }
+
+        navigate({
+            pathname: `${baseRoute}/${channelID}`,
+            search: `message_id=${baseMessage}`
         })
     }
 

--- a/frontend/src/components/layout/Sidebar/MentionsButton.tsx
+++ b/frontend/src/components/layout/Sidebar/MentionsButton.tsx
@@ -179,19 +179,21 @@ const MentionsList = () => {
 const MentionItem = ({ mention }: { mention: MentionObject }) => {
     const { workspaceID } = useParams()
 
-    const { to, baseMessage } = useMemo(() => {
+    const to = useMemo(() => {
         const w = mention.workspace ? mention.workspace : workspaceID
         if (mention.is_thread) {
-            return { to: `/${w}/threads/${mention.channel_id}` }
+            return { path: `/${w}/threads/${mention.channel_id}`, search: undefined }
         }
-        return { to: `/${w}/${mention.channel_id}`, baseMessage: mention.name }
+        return { path: `/${w}/${mention.channel_id}`, search: `message_id=${mention.name}` }
     }, [mention, workspaceID])
 
     return (
         <Popover.Close>
             <Link
-                to={to}
-                state={{ baseMessage }}
+                to={{
+                    pathname: to.path,
+                    search: to.search
+                }}
                 className="block py-3 px-4 hover:bg-gray-2 dark:hover:bg-gray-4 text-left"
             >
                 <HStack gap="3" justify="between" align="start">

--- a/frontend/src/pages/ChatSpace.tsx
+++ b/frontend/src/pages/ChatSpace.tsx
@@ -5,7 +5,7 @@ import { FullPageLoader } from "@/components/layout/Loaders/FullPageLoader"
 import { useCurrentChannelData } from "@/hooks/useCurrentChannelData"
 import { useEffect } from "react"
 import { Box, Grid } from '@radix-ui/themes'
-import { Outlet, useLocation, useParams } from "react-router-dom"
+import { Outlet, useParams, useSearchParams } from "react-router-dom"
 import { useSWRConfig } from "frappe-react-sdk"
 import { UnreadChannelCountItem, UnreadCountData } from "@/utils/channel/ChannelListProvider"
 import { useIsMobile } from "@/hooks/useMediaQuery"
@@ -32,7 +32,9 @@ const ChatSpaceArea = ({ channelID }: { channelID: string }) => {
     const { channel, error, isLoading } = useCurrentChannelData(channelID)
     const { mutate, cache } = useSWRConfig()
 
-    const { state } = useLocation()
+    const [searchParams] = useSearchParams()
+
+    const baseMessage = searchParams.get('message_id')
 
     useEffect(() => {
 
@@ -44,7 +46,7 @@ const ChatSpaceArea = ({ channelID }: { channelID: string }) => {
         // If unread count is present
         if (unread_count?.data) {
             // If the user entered the channel without a base message
-            if (!state?.baseMessage) {
+            if (!baseMessage) {
                 // Mutate the unread channel count to set the unread count of the current channel to 0
                 //@ts-ignore
                 mutate('unread_channel_count', (d: { message: UnreadCountData } | undefined) => {
@@ -74,7 +76,7 @@ const ChatSpaceArea = ({ channelID }: { channelID: string }) => {
             }
         }
 
-    }, [channelID, state?.baseMessage])
+    }, [channelID, baseMessage])
 
     return <Grid columns={threadID && !isMobile ? "2" : "1"} gap="2" rows="repeat(2, 64px)" width="auto" className="dark:bg-gray-2 bg-white h-screen">
         {threadID && isMobile ? null : <Box>

--- a/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
+++ b/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
@@ -45,6 +45,7 @@ class RavenChannelMember(Document):
 				)
 
 	def before_insert(self):
+		self.last_visit = frappe.utils.now()
 		# 1. A user cannot be a member of a channel more than once
 		if frappe.db.exists(
 			"Raven Channel Member", {"channel_id": self.channel_id, "user_id": self.user_id}

--- a/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
+++ b/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
@@ -28,9 +28,6 @@ class RavenChannelMember(Document):
 		user_id: DF.Link
 	# end: auto-generated types
 
-	def before_validate(self):
-		self.last_visit = frappe.utils.now()
-
 	def validate(self):
 		if (
 			self.has_value_changed("is_admin")


### PR DESCRIPTION
Copy links of messages to be shared on other platforms. Works for threads as well - it will open the thread in the thread explorer page.

https://github.com/user-attachments/assets/75d41034-b0a3-496d-b92a-701ccf6ca4a5

![CleanShot 2025-03-05 at 22 43 25@2x](https://github.com/user-attachments/assets/7fa78d5b-db40-40e3-bd68-a7581f51112a)

This also works with Message Actions - example: autofilling the reference of a support ticket

Closes #1447 
