### PR TITLE
feat(mobile): setup SWR config for React Native

### DIFF
--- a/apps/mobile/app/[site_id]/_layout.tsx
+++ b/apps/mobile/app/[site_id]/_layout.tsx
@@ -7,6 +7,7 @@ import FullPageLoader from "@components/layout/FullPageLoader";
 import { getAccessToken, getSiteFromStorage, getTokenEndpoint, storeAccessToken } from "@lib/auth";
 import Providers from "@lib/Providers";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+import FrappeNativeProvider from "@lib/FrappeNativeProvider";
 
 export default function SiteLayout() {
 
@@ -83,14 +84,7 @@ export default function SiteLayout() {
     return <>
         {loading ? <FullPageLoader /> :
             <SiteContext.Provider value={siteInfo}>
-                <FrappeProvider
-                    url={siteInfo?.url}
-                    tokenParams={{
-                        type: 'Bearer',
-                        useToken: true,
-                        token: () => accessToken?.accessToken || '',
-                    }}
-                    siteName={siteInfo?.sitename}>
+                <FrappeNativeProvider siteInfo={siteInfo} accessToken={accessToken}>
                     <Providers>
                         <BottomSheetModalProvider>
                             <Stack>
@@ -103,7 +97,7 @@ export default function SiteLayout() {
                             </Stack>
                         </BottomSheetModalProvider>
                     </Providers>
-                </FrappeProvider>
+                </FrappeNativeProvider>
             </SiteContext.Provider>
         }
     </>

--- a/apps/mobile/lib/FrappeNativeProvider.tsx
+++ b/apps/mobile/lib/FrappeNativeProvider.tsx
@@ -1,0 +1,82 @@
+import { TokenResponse } from 'expo-auth-session'
+import { FrappeProvider } from 'frappe-react-sdk'
+import { PropsWithChildren } from 'react'
+import { SiteInformation } from 'types/SiteInformation'
+import { AppState, AppStateStatus } from 'react-native'
+import { NetworkState, addNetworkStateListener } from 'expo-network'
+
+const FrappeNativeProvider = ({ siteInfo, accessToken, children }: PropsWithChildren<{ siteInfo: SiteInformation | null, accessToken: TokenResponse | null }>) => {
+
+    return (
+        <FrappeProvider
+            url={siteInfo?.url}
+            tokenParams={{
+                type: 'Bearer',
+                useToken: true,
+                token: () => accessToken?.accessToken || '',
+            }}
+            siteName={siteInfo?.sitename}
+
+            swrConfig={{
+                // A provider is required to use initFocus and initReconnect
+                provider: () => new Map(),
+                isVisible() {
+                    return AppState.currentState === 'active'
+                },
+                isOnline() {
+                    // We can't get the network state synchronously, so we'll assume online
+                    // The initReconnect handler will handle the actual network state changes
+                    return true
+                },
+                initFocus(callback) {
+
+                    let appState = AppState.currentState
+
+                    const onAppStateChange = (nextAppState: AppStateStatus) => {
+
+                        /* If it's resuming from background or inactive mode to active one */
+                        if (appState.match(/inactive|background/) && nextAppState === 'active') {
+                            callback()
+                        }
+                        appState = nextAppState
+                    }
+
+                    // Subscribe to the app state change events
+                    const subscription = AppState.addEventListener('change', onAppStateChange)
+
+                    return () => {
+                        subscription.remove()
+                    }
+                },
+                initReconnect(callback) {
+
+                    let isConnected = true
+
+                    const onNetworkStateChange = (state: NetworkState) => {
+                        const currentIsConnected = state.isInternetReachable ?? (state.isConnected ?? false)
+
+                        if (currentIsConnected !== isConnected) {
+                            isConnected = currentIsConnected
+                            if (isConnected) {
+                                // Callback when the network is restored
+                                callback()
+                            }
+                        }
+                    }
+
+                    const subscription = addNetworkStateListener(onNetworkStateChange)
+
+                    return () => {
+                        subscription.remove()
+                    }
+                },
+
+            }}
+
+        >
+            {children}
+        </FrappeProvider>
+    )
+}
+
+export default FrappeNativeProvider

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -47,6 +47,7 @@
     "expo-intent-launcher": "~12.0.2",
     "expo-linking": "~7.0.5",
     "expo-navigation-bar": "~4.0.8",
+    "expo-network": "~7.0.5",
     "expo-router": "~4.0.17",
     "expo-secure-store": "~14.0.1",
     "expo-sharing": "~13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6295,6 +6295,11 @@ expo-navigation-bar@~4.0.8:
     "@react-native/normalize-colors" "0.76.7"
     debug "^4.3.2"
 
+expo-network@~7.0.5:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/expo-network/-/expo-network-7.0.5.tgz#14d5b001850d77b23bd0b0f37b2b5ea0e1f64a97"
+  integrity sha512-5dlowKAimhIDN1/lBRnN6SSH6c07f12R3QrfLf3b3GEr6D+EijH2wE537mmwPh1p+254LAkm0Z5ZEXxbwII4sA==
+
 expo-router@~4.0.17:
   version "4.0.17"
   resolved "https://registry.yarnpkg.com/expo-router/-/expo-router-4.0.17.tgz#8cecc68f189fd93d69b239986f63e040ee15f63a"


### PR DESCRIPTION
SWR config is set up to listen to both network and "focus" states - API calls will be revalidated when network is restored or when app is brought back into focus.