### PR TITLE
feat(mobile): automatically refresh access tokens

### DIFF
--- a/apps/mobile/app/[site_id]/_layout.tsx
+++ b/apps/mobile/app/[site_id]/_layout.tsx
@@ -1,13 +1,14 @@
 import { router, Stack, useLocalSearchParams } from "expo-router";
-import { createContext, useEffect, useState } from "react";
+import { createContext, useEffect, useState, useRef, useCallback } from "react";
 import { SiteInformation } from "../../types/SiteInformation";
 import { TokenResponse } from "expo-auth-session";
-import { FrappeProvider } from "frappe-react-sdk";
 import FullPageLoader from "@components/layout/FullPageLoader";
 import { getAccessToken, getSiteFromStorage, getTokenEndpoint, storeAccessToken } from "@lib/auth";
 import Providers from "@lib/Providers";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import FrappeNativeProvider from "@lib/FrappeNativeProvider";
+import { useNetworkState } from 'expo-network';
+import { toast } from "sonner-native";
 
 export default function SiteLayout() {
 
@@ -20,8 +21,70 @@ export default function SiteLayout() {
 
     const [loading, setLoading] = useState(true)
     const [siteInfo, setSiteInfo] = useState<SiteInformation | null>(null)
-    const [accessToken, setAccessToken] = useState<TokenResponse | null>(null)
+    const accessTokenRef = useRef<TokenResponse | null>(null)
+    const networkState = useNetworkState();
 
+    // Constants for token refresh timing
+    const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes in milliseconds
+    const REFRESH_THRESHOLD = REFRESH_INTERVAL + (2 * 60 * 1000); // Check interval + 2 minutes buffer
+
+    // Token refresh interval effect - now only handles periodic checks
+    useEffect(() => {
+
+        const shouldRefreshToken = (token: TokenResponse): boolean => {
+            if (!token.expiresIn) return false;
+
+            const expirationTime = token.issuedAt + token.expiresIn * 1000; // Convert expiresIn to milliseconds
+            const currentTime = Date.now();
+            const timeUntilExpiry = expirationTime - currentTime;
+
+            // Refresh if token will expire within our threshold
+            return timeUntilExpiry <= REFRESH_THRESHOLD;
+        };
+
+        const refreshTokenIfNeeded = async () => {
+            if (!accessTokenRef.current || !siteInfo) return;
+
+            const isOnline = networkState.isConnected && networkState.isInternetReachable;
+            if (!isOnline) {
+                console.log("Skipping token refresh - device is offline");
+                return;
+            }
+
+            // Check if token needs refresh based on our proactive threshold
+            if (shouldRefreshToken(accessTokenRef.current)) {
+                console.log("Proactively refreshing token");
+                try {
+                    const newToken = await accessTokenRef.current.refreshAsync(
+                        {
+                            clientId: siteInfo.client_id,
+                        },
+                        {
+                            tokenEndpoint: getTokenEndpoint(siteInfo.url),
+                        }
+                    );
+                    await storeAccessToken(siteInfo.sitename, newToken);
+                    accessTokenRef.current = newToken;
+                    console.log("Token refreshed successfully");
+                } catch (error) {
+                    console.error("Token refresh failed:", error);
+                    if (isOnline) {
+                        toast.error("You have been logged out of the site. Please login again.")
+                        router.replace('/landing');
+                    }
+                }
+            }
+        };
+
+        const refreshInterval = setInterval(() => {
+            const isOnline = networkState.isConnected && networkState.isInternetReachable;
+            if (isOnline) {
+                refreshTokenIfNeeded();
+            }
+        }, REFRESH_INTERVAL);
+
+        return () => clearInterval(refreshInterval);
+    }, [siteInfo, networkState]);
 
     useEffect(() => {
 
@@ -50,7 +113,9 @@ export default function SiteLayout() {
                 if (!accessToken) {
                     router.replace('/landing')
 
-                    // TODO: Show the user a toast saying that the site is not found
+                    // Show the user a toast saying that the site is not found
+
+                    toast.error("The site you are trying to access was not found. Please try logging in again.")
 
                     return null
                 }
@@ -73,18 +138,23 @@ export default function SiteLayout() {
             })
             .then(tokenResponse => {
                 if (!tokenResponse) return
-
-                setAccessToken(tokenResponse)
+                accessTokenRef.current = tokenResponse
             })
             .then(() => {
                 setLoading(false)
             })
     }, [site_id])
 
+    // We need to check if the access token is expired or not and keep it refreshed
+
+    const getToken = useCallback(() => {
+        return accessTokenRef.current?.accessToken || ''
+    }, [])
+
     return <>
         {loading ? <FullPageLoader /> :
             <SiteContext.Provider value={siteInfo}>
-                <FrappeNativeProvider siteInfo={siteInfo} accessToken={accessToken}>
+                <FrappeNativeProvider siteInfo={siteInfo} getAccessToken={getToken}>
                     <Providers>
                         <BottomSheetModalProvider>
                             <Stack>

--- a/apps/mobile/lib/FrappeNativeProvider.tsx
+++ b/apps/mobile/lib/FrappeNativeProvider.tsx
@@ -1,11 +1,10 @@
-import { TokenResponse } from 'expo-auth-session'
 import { FrappeProvider } from 'frappe-react-sdk'
 import { PropsWithChildren } from 'react'
 import { SiteInformation } from 'types/SiteInformation'
 import { AppState, AppStateStatus } from 'react-native'
 import { NetworkState, addNetworkStateListener } from 'expo-network'
 
-const FrappeNativeProvider = ({ siteInfo, accessToken, children }: PropsWithChildren<{ siteInfo: SiteInformation | null, accessToken: TokenResponse | null }>) => {
+const FrappeNativeProvider = ({ siteInfo, getAccessToken, children }: PropsWithChildren<{ siteInfo: SiteInformation | null, getAccessToken: () => string }>) => {
 
     return (
         <FrappeProvider
@@ -13,7 +12,7 @@ const FrappeNativeProvider = ({ siteInfo, accessToken, children }: PropsWithChil
             tokenParams={{
                 type: 'Bearer',
                 useToken: true,
-                token: () => accessToken?.accessToken || '',
+                token: getAccessToken,
             }}
             siteName={siteInfo?.sitename}
 


### PR DESCRIPTION
Set an interval of 5 minutes - refresh tokens that are going to expire in the next 7 minutes. (These values can be tweaked later.) This prevents APIs from failing while using the mobile app.