### PR TITLE
feat: add support for server scripts in Message Actions

### DIFF
--- a/frontend/src/pages/settings/MessageActions/ViewMessageAction.tsx
+++ b/frontend/src/pages/settings/MessageActions/ViewMessageAction.tsx
@@ -7,7 +7,6 @@ import SettingsContentContainer from "@/components/layout/Settings/SettingsConte
 import SettingsPageHeader from "@/components/layout/Settings/SettingsPageHeader"
 import { HStack } from "@/components/layout/Stack"
 import { RavenMessageAction } from "@/types/RavenIntegrations/RavenMessageAction"
-import { isEmpty } from "@/utils/validations"
 import { Button } from "@radix-ui/themes"
 import { useFrappeGetDoc, useFrappeUpdateDoc, SWRResponse } from "frappe-react-sdk"
 import { useEffect } from "react"
@@ -41,9 +40,7 @@ const ViewMessageActionContent = ({ data, mutate }: { data: RavenMessageAction, 
         defaultValues: data
     })
 
-    const { formState: { dirtyFields } } = methods
-
-    const isDirty = !isEmpty(dirtyFields)
+    const { formState: { isDirty } } = methods
 
 
     const onSubmit = (data: RavenMessageAction) => {

--- a/frontend/src/types/RavenIntegrations/RavenMessageAction.ts
+++ b/frontend/src/types/RavenIntegrations/RavenMessageAction.ts
@@ -16,11 +16,13 @@ export interface RavenMessageAction{
 	/**	Enabled : Check	*/
 	enabled?: 0 | 1
 	/**	Action : Select	*/
-	action: "Create Document" | "Custom Function"
+	action: "Create Document" | "Custom Function" | "Server Script"
 	/**	Document Type : Link - DocType	*/
 	document_type?: string
 	/**	Custom Function Path : Small Text	*/
 	custom_function_path?: string
+	/**	Server Script : Link - Server Script	*/
+	server_script?: string
 	/**	Title : Data - Shown on the dialog	*/
 	title: string
 	/**	Description : Small Text	*/

--- a/raven/api/message_actions.py
+++ b/raven/api/message_actions.py
@@ -90,3 +90,9 @@ def execute_action(action_id: str, message_id: str, values: dict):
 			return function_name(**values)
 		else:
 			frappe.throw(_("Function {0} not found").format(action.custom_function_path))
+
+	if action.action == "Server Script":
+		script = frappe.get_doc("Server Script", action.server_script)
+		if script.disabled:
+			frappe.throw(_("Server Script {0} is disabled").format(action.server_script))
+		script.execute_method()

--- a/raven/raven_integrations/doctype/raven_message_action/raven_message_action.json
+++ b/raven/raven_integrations/doctype/raven_message_action/raven_message_action.json
@@ -12,6 +12,7 @@
   "action",
   "document_type",
   "custom_function_path",
+  "server_script",
   "dialog_properties_tab",
   "title",
   "description",
@@ -41,7 +42,7 @@
    "fieldname": "action",
    "fieldtype": "Select",
    "label": "Action",
-   "options": "Create Document\nCustom Function",
+   "options": "Create Document\nCustom Function\nServer Script",
    "reqd": 1
   },
   {
@@ -91,11 +92,18 @@
    "fieldname": "dialog_properties_tab",
    "fieldtype": "Tab Break",
    "label": "Dialog Properties"
+  },
+  {
+   "fieldname": "server_script",
+   "fieldtype": "Link",
+   "label": "Server Script",
+   "options": "Server Script"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-07 23:11:20.120854",
+ "modified": "2025-03-10 23:03:38.680632",
  "modified_by": "Administrator",
  "module": "Raven Integrations",
  "name": "Raven Message Action",
@@ -136,6 +144,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "action_name",
  "show_title_field_in_link": 1,
  "sort_field": "creation",


### PR DESCRIPTION
Added a new option for Server Scripts in Message Actions.

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/93c609ab-1c19-4b15-9f0a-5329fc8ae47d" />

Also added inline docs:

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/e10d4262-98e5-43c5-98c8-802742b2ba45" />


