### PR TITLE
feat(web): use favicon available in Website Settings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,12 +7,12 @@
     content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <title>{{ app_name }}</title>
   <meta name="description" content="Simple, work messaging tool.">
-  <link rel="apple-touch-icon" sizes="180x180" href="/assets/raven/manifest/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/assets/raven/manifest/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/assets/raven/manifest/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ apple_touch_icon }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ icon_32 }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ icon_16 }}">
   <meta name="msapplication-TileColor" content="#000000">
   <meta name="theme-color" content="#191919">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#000000">
+  <link rel="mask-icon" href="{{ mask_icon }}" color="#000000">
 
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-title" content="{{ app_name }} | Raven" />

--- a/raven/www/raven.py
+++ b/raven/www/raven.py
@@ -52,6 +52,13 @@ def get_context(context):
 	else:
 		context["app_name"] = "Raven"
 
+	favicon = frappe.get_website_settings("favicon")
+
+	context["icon_32"] = favicon or "/assets/raven/manifest/favicon-32x32.png"
+	context["icon_16"] = favicon or "/assets/raven/manifest/favicon-16x16.png"
+	context["apple_touch_icon"] = favicon or "/assets/raven/manifest/apple-touch-icon.png"
+	context["mask_icon"] = favicon or "/assets/raven/manifest/safari-pinned-tab.svg"
+
 	if frappe.session.user != "Guest":
 		capture("active_site", "raven")
 


### PR DESCRIPTION
Will probably have a different field somewhere in Raven Settings to set a specific favicon + app logo later. Right now it just uses it from Website Settings