### PR TITLE
feat(mobile): store push token for each site

### DIFF
--- a/apps/mobile/hooks/useFirebasePushTokenListener.ts
+++ b/apps/mobile/hooks/useFirebasePushTokenListener.ts
@@ -1,0 +1,39 @@
+import { useContext, useEffect, useRef } from 'react'
+import * as Device from 'expo-device';
+import { AuthorizationStatus, getMessaging } from '@react-native-firebase/messaging';
+import useSiteContext from './useSiteContext';
+import { FrappeConfig, FrappeContext } from 'frappe-react-sdk';
+
+const messaging = getMessaging()
+
+const useFirebasePushTokenListener = () => {
+
+    const siteInfo = useSiteContext()
+
+    const { call } = useContext(FrappeContext) as FrappeConfig
+
+    const callMade = useRef(false)
+
+    useEffect(() => {
+
+        if (callMade.current) return
+        callMade.current = true
+
+        // When the site is switched, fetch the token and store it in the database
+        if (siteInfo) {
+            messaging.requestPermission().then(async (authorizationStatus) => {
+                if (authorizationStatus === AuthorizationStatus.AUTHORIZED) {
+                    const token = await messaging.getToken()
+                    call.post('raven.api.notification.subscribe', {
+                        fcm_token: token,
+                        environment: 'Mobile',
+                        device_information: Device.deviceName
+                    })
+                }
+            })
+        }
+
+    }, [siteInfo])
+}
+
+export default useFirebasePushTokenListener

--- a/apps/mobile/lib/Providers.tsx
+++ b/apps/mobile/lib/Providers.tsx
@@ -16,6 +16,7 @@ import { useUnreadThreadsCountEventListener } from '@hooks/useUnreadThreadsCount
 import useCurrentRavenUser from '@raven/lib/hooks/useCurrentRavenUser'
 import { useActiveSocketConnection } from '@hooks/useActiveSocketConnection'
 import { useFetchActiveUsersRealtime } from '@hooks/useFetchActiveUsers'
+import useFirebasePushTokenListener from '@hooks/useFirebasePushTokenListener'
 
 const Providers = (props: PropsWithChildren) => {
 
@@ -86,6 +87,8 @@ const WorkspaceProvider = ({ children }: PropsWithChildren) => {
     useFetchUnreadMessageCount()
 
     useFetchActiveUsersRealtime()
+
+    useFirebasePushTokenListener()
 
     // Listen to channel members updated events and invalidate the channel members cache
     const { mutate } = useSWRConfig()


### PR DESCRIPTION
When we switch sites, we need to get the push notification token and store it in the site. Maybe we don't need the toggle in the profile page for push notifications at all.