### PR TITLE
perf: use after_response to send notifications

### DIFF
--- a/raven/api/raven_message.py
+++ b/raven/api/raven_message.py
@@ -181,7 +181,7 @@ def get_saved_messages():
 			raven_message._liked_by,
 			raven_channel.workspace,
 			raven_message.thumbnail_width,
-			raven_message.thumbnail_height
+			raven_message.thumbnail_height,
 		)
 		.where(raven_message._liked_by.like("%" + frappe.session.user + "%"))
 		.where(

--- a/raven/api/raven_mobile.py
+++ b/raven/api/raven_mobile.py
@@ -53,9 +53,7 @@ def create_oauth_client():
 	oauth_client.grant_type = "Authorization Code"
 	oauth_client.response_type = "Code"
 	oauth_client.allowed_roles = []
-	oauth_client.append("allowed_roles", {
-		"role": "Raven User"
-	})
+	oauth_client.append("allowed_roles", {"role": "Raven User"})
 	oauth_client.save()
 	raven_settings.oauth_client = oauth_client.name
 	raven_settings.save()

--- a/raven/notification.py
+++ b/raven/notification.py
@@ -1,6 +1,22 @@
 import frappe
 
 
+def send_notification_for_message(message):
+	"""
+	Send a push notification for a message.
+
+	This is called in the "after_response" hook for user initiated requests.
+	"""
+
+	channel_doc = frappe.get_cached_doc("Raven Channel", message.channel_id)
+
+	if channel_doc.is_direct_message and not channel_doc.is_self_message:
+		message.send_notification_for_direct_message()
+
+	else:
+		message.send_notification_for_channel_message()
+
+
 def send_notification_to_user(user_id, title, message, data=None, user_image_id=None):
 	"""
 	Send a push notification to a user


### PR DESCRIPTION
Speeds up sending messages since notifications will be sent after returning the message response