### PR TITLE
fix: invalid query error if not workspaces or users exist

### DIFF
--- a/raven/permissions.py
+++ b/raven/permissions.py
@@ -340,7 +340,12 @@ def raven_workspace_query(user):
 		"Raven Workspace Member", filters={"user": user}, fields=["workspace"]
 	)
 
-	return f"`tabRaven Workspace`.name in ({', '.join([frappe.db.escape(member.workspace) for member in workspace_members])}) OR `tabRaven Workspace`.type = 'Public'"
+	workspace_names = [frappe.db.escape(member.workspace) for member in workspace_members]
+
+	if workspace_names:
+		return f"`tabRaven Workspace`.name in ({', '.join(workspace_names)}) OR `tabRaven Workspace`.type = 'Public'"
+	else:
+		return "`tabRaven Workspace`.type = 'Public'"
 
 
 def raven_workspace_member_query(user):
@@ -352,7 +357,12 @@ def raven_workspace_member_query(user):
 		"Raven Workspace Member", filters={"user": user}, fields=["workspace"]
 	)
 
-	return f"`tabRaven Workspace Member`.workspace in ({', '.join([frappe.db.escape(member.workspace) for member in workspace_members])})"
+	workspace_names = [frappe.db.escape(member.workspace) for member in workspace_members]
+
+	if workspace_names:
+		return f"`tabRaven Workspace Member`.workspace in ({', '.join(workspace_names)})"
+	else:
+		return "`tabRaven Workspace`.type = 'Public'"
 
 
 def raven_channel_query(user):


### PR DESCRIPTION
If the list view in frappe desk is opened before workspaces or members are created, the following error occurs:
### App Versions
```
{
	"erpnext": "15.58.1",
	"frappe": "15.64.0",
	"raven": "2.2.2"
}
```
### Route
```
List/Raven Workspace/List
```
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1739, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 885, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/reportview.py", line 34, in get
    data = compress(execute(**args), args=args)
                    ^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/reportview.py", line 80, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/db_query.py", line 191, in execute
    result = self.build_and_run()
             ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/db_query.py", line 232, in build_and_run
    return frappe.db.sql(
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 230, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') OR `tabRaven Workspace`.type = 'Public')\n\t\t\t\n\t\t\t order by `tabRaven Workspa...' at line 3")

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"doctype": "Raven Workspace",
		"fields": "[\"`tabRaven Workspace`.`name`\",\"`tabRaven Workspace`.`owner`\",\"`tabRaven Workspace`.`creation`\",\"`tabRaven Workspace`.`modified`\",\"`tabRaven Workspace`.`modified_by`\",\"`tabRaven Workspace`.`_user_tags`\",\"`tabRaven Workspace`.`_comments`\",\"`tabRaven Workspace`.`_assign`\",\"`tabRaven Workspace`.`_liked_by`\",\"`tabRaven Workspace`.`docstatus`\",\"`tabRaven Workspace`.`idx`\",\"`tabRaven Workspace`.`workspace_name`\",\"`tabRaven Workspace`.`type`\"]",
		"filters": "[]",
		"order_by": "`tabRaven Workspace`.`creation` desc",
		"start": 0,
		"page_length": 20,
		"view": "List",
		"group_by": null,
		"with_comment_count": 1
	},
	"freeze": false,
	"freeze_message": "Loading...",
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.reportview.get",
	"request_id": "1d374d46-b8cd-4bd8-b5a8-863b75b47a4f"
}
```
### Response Data
```
{
	"exception": "pymysql.err.ProgrammingError: (1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') OR `tabRaven Workspace`.type = 'Public')\\n\\t\\t\\t\\n\\t\\t\\t order by `tabRaven Workspa...' at line 3\")",
	"exc_type": "ProgrammingError",
	"_debug_messages": "[\"Syntax error in query:\\nselect `tabRaven Workspace`.`name`, `tabRaven Workspace`.`owner`, `tabRaven Workspace`.`creation`, `tabRaven Workspace`.`modified`, `tabRaven Workspace`.`modified_by`, `tabRaven Workspace`.`_user_tags`, `tabRaven Workspace`.`_comments`, `tabRaven Workspace`.`_assign`, `tabRaven Workspace`.`_liked_by`, `tabRaven Workspace`.`docstatus`, `tabRaven Workspace`.`idx`, `tabRaven Workspace`.`workspace_name`, `tabRaven Workspace`.`type`\\n\\t\\t\\tfrom `tabRaven Workspace`\\n\\t\\t\\twhere (`tabRaven Workspace`.name in () OR `tabRaven Workspace`.type = 'Public')\\n\\t\\t\\t\\n\\t\\t\\t order by `tabRaven Workspace`.`creation` desc\\n\\t\\t\\tlimit 20 offset 0 /* FRAPPE_TRACE_ID: 1d374d46-b8cd-4bd8-b5a8-863b75b47a4f */ \"]"
}
```