### PR TITLE
fix: function call and fields in get_list

### DIFF
--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe import _
+from frappe import _, client
 
 
 def get_document(doctype: str, document_id: str):
@@ -7,7 +7,7 @@ def get_document(doctype: str, document_id: str):
 	Get a document from the database
 	"""
 	# Use the frappe.client.get method to get the document with permissions (both read and field level read)
-	return frappe.client.get(doctype, name=document_id)
+	return client.get(doctype, name=document_id)
 
 
 def get_documents(doctype: str, document_ids: list):
@@ -17,7 +17,7 @@ def get_documents(doctype: str, document_ids: list):
 	docs = []
 	for document_id in document_ids:
 		# Use the frappe.client.get method to get the document with permissions applied
-		docs.append(frappe.client.get(doctype, name=document_id))
+		docs.append(client.get(doctype, name=document_id))
 	return docs
 
 
@@ -149,5 +149,15 @@ def get_list(doctype: str, filters: dict = None, fields: list = None, limit: int
 	if fields is None:
 		fields = ["*"]
 
+	else:
+		meta = frappe.get_meta(doctype)
+		filtered_fields = ["name as document_id"]
+		if "title" in fields:
+			filtered_fields.append(meta.get_title_field())
+
+		for field in fields:
+			if meta.has_field(field) and field not in filtered_fields:
+				filtered_fields.append(field)
+
 	# Use the frappe.get_list method to get the list of documents
-	return frappe.get_list(doctype, filters=filters, fields=fields, limit=limit)
+	return frappe.get_list(doctype, filters=filters, fields=filtered_fields, limit=limit)


### PR DESCRIPTION
Hello,

I am trying to setup a simple process to allow users to query the help articles of a site.
I have created two functions for an assistant:
1. get_help_article_list: Get List for the doctype Help Article
2. get_help_docs: Get Multiple Documents for the doctype Help Article

I encountered two issues:
1. Issue importing frappe.client (Frappe version-15)
I propose to import it explicitely at the top of the file.
```python
Traceback (most recent call last):
  File "apps/raven/raven/ai/handler.py", line 137, in handle_requires_action
    function_output = get_document(function.reference_doctype, **args)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/raven/raven/ai/functions.py", line 10, in get_document
    return frappe.client.get(doctype, name=document_id)
           ^^^^^^^^^^^^^
AttributeError: module 'frappe' has no attribute 'client'. Did you mean: 'cint'?
```

2. In many cases, when calling GET LIST, the arguments passed to `get_list` where ["title", "id"].
I propose to check that the fields requested do exist before calling `get_list` and to always return `document_id` to make sure it is properly passed to the subsequent requests.
In many cases, the next call used the title as ID, which lead to the following error:
```python
Traceback (most recent call last):
  File "apps/raven/raven/ai/handler.py", line 140, in handle_requires_action
    function_output = get_document(function.reference_doctype, **args)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/raven/raven/ai/functions.py", line 10, in get_document
    return client.get(doctype, name=document_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 30, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/client.py", line 87, in get
    doc = frappe.get_doc(doctype, name)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1325, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 83, in get_doc
    return controller(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/website/website_generator.py", line 16, in __init__
    super().__init__(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 126, in __init__
    self.load_from_db()
  File "apps/frappe/frappe/model/document.py", line 172, in load_from_db
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 637, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 609, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 557, in _raise_exception
    raise exc
frappe.exceptions.DoesNotExistError: Article d'aide Venir au Tiers Lieu introuvable
```

What do you think ?

Thanks a lot !