### PR TITLE
fix: permission error on department creation by specifying parent_doctype

### DIFF
--- a/raven/raven_integrations/controllers/department.py
+++ b/raven/raven_integrations/controllers/department.py
@@ -27,7 +27,11 @@ def after_insert(doc, method):
 
 	# Get the workspace based on the company of the department else use the default workspace
 	workspace = frappe.get_list(
-		"Raven HR Company Workspace", {"company": doc.company}, pluck="raven_workspace", limit=1
+		"Raven HR Company Workspace",
+		{"company": doc.company},
+		pluck="raven_workspace",
+		limit=1,
+		parent_doctype="Raven Settings",
 	)
 
 	if workspace:


### PR DESCRIPTION
When creating a new department as a non Administrator User the following error gets thrown:
![image](https://github.com/user-attachments/assets/a3f5a0b1-06c6-452d-a232-835ad2eafe4d)

This PR fixes this.