### PR TITLE
fix: handle exception in openai assistant creation

### DIFF
--- a/raven/raven_bot/doctype/raven_bot/raven_bot.py
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.py
@@ -126,7 +126,7 @@ class RavenBot(Document):
 					)
 				)
 			else:
-				frappe.throw(e)
+				frappe.throw(str(e))
 
 		self.db_set("openai_assistant_id", assistant.id)
 


### PR DESCRIPTION
Fixes a bug where calling `frappe.throw(e)` with a non-string exception caused a `TypeError`, leading to a confusing error message for the user.

### Before
![image](https://github.com/user-attachments/assets/c68b8264-d206-4a21-bff6-cb41a3e91f73)

### After
![image](https://github.com/user-attachments/assets/c89fb0cf-6d35-412c-a392-fff56a89169c)
