### PR TITLE
Allow opening Raven bot chat in new tab via icon click

### DIFF
--- a/frontend/src/pages/settings/AI/ViewBot.tsx
+++ b/frontend/src/pages/settings/AI/ViewBot.tsx
@@ -102,23 +102,35 @@ const OpenChatButton = ({ bot }: { bot: RavenBot }) => {
 
     const currentWorkspace = localStorage.getItem('ravenLastWorkspace')
 
-    const openChat = () => {
-        call.post("raven.api.raven_channel.create_direct_message_channel", {
-            user_id: bot.raven_user
-        }).then((res) => {
-            if (currentWorkspace) {
-                navigate(`/${currentWorkspace}/${res.message}`)
-            } else {
-                navigate(`/channel/${res.message}`)
-            }
-        })
-    }
+    const createChatUrl = async (): Promise<string> => {
+        const res = await call.post("raven.api.raven_channel.create_direct_message_channel", {
+            user_id: bot.raven_user,
+        });
+
+        return currentWorkspace
+            ? `/${currentWorkspace}/${res.message}`
+            : `/channel/${res.message}`;
+    };
+
+    const handleButtonClick = async () => {
+        const url = await createChatUrl();
+        navigate(url);
+    };
+
+    const handleIconClick = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        const url = await createChatUrl();
+        window.open(url, "_blank");
+    };
 
     return <Button variant='surface' color='gray'
         type='button'
-        className="not-cal" onClick={openChat}>
+        className="not-cal" onClick={handleButtonClick}>
         Open Chat
-        <FiExternalLink />
+        <FiExternalLink
+            className="cursor-pointer rounded p-1 hover:bg-gray-150"
+            onClick={handleIconClick}
+        />
     </Button>
 }
 


### PR DESCRIPTION
This PR improves UX by enabling the external link icon next to "Open Chat" to open the direct message in a new tab.  
- Button click opens the chat in the current tab (via router)  
- Icon click opens it in a new tab (`window.open`)  
- Prevents propagation to avoid dual triggers
