### PR TITLE
fix(web): update thread reply counts in realtime

### DIFF
--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -73,6 +73,16 @@ const MainPageContent = () => {
             }, {
                 revalidate: false
             })
+
+            // Dispatch a custom event that ThreadsList can listen to if it's mounted
+            window.dispatchEvent(new CustomEvent('thread_updated', {
+                detail: {
+                    threadId: event.channel_id,
+                    sentBy: event.sent_by,
+                    lastMessageTimestamp: event.last_message_timestamp,
+                    numberOfReplies: event.number_of_replies
+                }
+            }))
         }
 
         // Unread count only needs to be fetched for certain conditions


### PR DESCRIPTION
Since we are using Infinite loading on the threads list, it made sense to just dispatch a custom event and listen to it if the threads list is mounted. This is performant since a new thread reply does not trigger a revalidation of the entire thread list.