### PR TITLE
Fix clipboard copy error and add copied feedback

### DIFF
--- a/frontend/src/components/layout/CodeBlock.tsx
+++ b/frontend/src/components/layout/CodeBlock.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { common, createLowlight } from 'lowlight'
@@ -27,6 +28,7 @@ type Props = {
 }
 
 const CodeBlock = ({ code }: Props) => {
+    const [copied, setCopied] = useState(false)
 
     const editor = useEditor({
         editorProps: {
@@ -44,20 +46,38 @@ const CodeBlock = ({ code }: Props) => {
         content: `<pre><code>${code}</code></pre>`
     })
 
-    const onCopy = () => {
-        navigator.clipboard.writeText(code)
+    const onCopy = async () => {
+        try {
+          if (navigator?.clipboard?.writeText) {
+            await navigator.clipboard.writeText(code)
+          } else {
+            const textarea = document.createElement('textarea')
+            textarea.value = code
+            textarea.setAttribute('readonly', '')
+            textarea.style.position = 'absolute'
+            textarea.style.left = '-9999px'
+            document.body.appendChild(textarea)
+            textarea.select()
+            document.execCommand('copy')
+            document.body.removeChild(textarea)
+          }
 
-        toast.success('Copied to clipboard', {
-            duration: 800
-        })
-    }
+          setCopied(true)
+          toast.success('Copied to clipboard', { duration: 800 })
+          setTimeout(() => setCopied(false), 2500)
+        } catch (err) {
+          console.error('Copy failed:', err)
+          toast.error('Failed to copy')
+        }
+      }
+
 
     if (!editor) return null
 
     return (
         <div className='relative'>
             <EditorContent editor={editor} />
-            <Tooltip content='Copy'>
+            <Tooltip content={copied ? 'Copied' : 'Copy'}>
                 <IconButton
                     variant='ghost'
                     size='2'
@@ -66,7 +86,7 @@ const CodeBlock = ({ code }: Props) => {
                     className='absolute right-3 top-7 text-gray-8 hover:text-gray-1'
                     onClick={onCopy}
                 >
-                    <BiCopy />
+                    {copied ? <BiClipboard /> : <BiCopy />}
                 </IconButton>
             </Tooltip>
         </div>


### PR DESCRIPTION
### What does this do?

- Fixes runtime error when `navigator.clipboard` is undefined
- Adds fallback method for older or insecure browsers
- Adds "Copied" feedback with tooltip and icon

### Why?

Clipboard copy was failing in some environments (e.g. HTTP or older browsers). This change makes the copy function more reliable and user-friendly.

**Before**

[before.webm](https://github.com/user-attachments/assets/c76192ae-0f97-4d2d-8458-48f4bada2b8c)

**After**

[after.webm](https://github.com/user-attachments/assets/edf571dd-ca33-4dd6-a099-dbb0474f5d4a)
