### PR TITLE
Add audio preview with play/pause support in FileUploadBox

### DIFF
--- a/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
@@ -1,10 +1,10 @@
 import { Button, Flex, FlexProps, IconButton, Text } from "@radix-ui/themes";
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useImperativeHandle, useState, useEffect } from "react";
 import { Accept, useDropzone } from "react-dropzone";
 import { toast } from "sonner";
 import { useGetFilePreviewUrl } from "@/hooks/useGetFilePreviewUrl";
 import { Loader } from "@/components/common/Loader";
-import { BiTrash } from "react-icons/bi";
+import { BiTrash, BiPlayCircle, BiPauseCircle } from "react-icons/bi";
 import { CustomFile } from "../../file-upload/FileDrop";
 import { FileUploadProgress } from "../../chat/ChatInput/FileInput/useFileUpload";
 import { getFileSize } from "../../file-upload/FileListItem";
@@ -126,12 +126,51 @@ const FileItem = ({ file, removeFile, uploadProgress }: FileItemProps) => {
     const isUploadComplete = uploadProgress?.[file.fileID]?.isComplete ?? false
     const progress = uploadProgress?.[file.fileID]?.progress ?? 0
 
+    const [audioEl, setAudioEl] = useState<HTMLAudioElement | null>(null);
+    const [isPlaying, setIsPlaying] = useState(false);
+
+    useEffect(() => {
+        if (previewURL && file.type?.startsWith('audio')) {
+            const audio = new Audio(previewURL);
+            setAudioEl(audio);
+            const handleEnded = () => setIsPlaying(false);
+            audio.addEventListener('ended', handleEnded);
+            return () => {
+                audio.pause();
+                audio.currentTime = 0;
+                audio.removeEventListener('ended', handleEnded);
+            };
+        }
+    }, [previewURL, file.type]);
+
+    const handleTogglePlay = () => {
+        if (!audioEl) return;
+        if (isPlaying) {
+            audioEl.pause();
+            setIsPlaying(false);
+        } else {
+            audioEl.play().then(() => setIsPlaying(true)).catch(console.error);
+        }
+    };
+
     return (
         <Flex width='100%' gap='2' mt='2' px='4' className='border rounded-md border-slate-8' justify={'between'}>
 
             <Flex align='center' justify='center' gap='2'>
                 <Flex align='center' justify='center' className='w-12 h-12'>
-                    {previewURL && <img src={previewURL} alt='File preview' className='w-10 h-10 aspect-square object-cover rounded-md' />}
+                    {file.type?.startsWith('audio') ? (
+                        <IconButton
+                            variant="ghost"
+                            color="blue"
+                            title={isPlaying ? 'Pause Audio' : 'Play Audio'}
+                            onClick={handleTogglePlay}
+                            size="3"
+                        >
+                            {isPlaying ? <BiPauseCircle size={24} /> : <BiPlayCircle size={24} />}
+                        </IconButton>
+                        ) : previewURL ? (
+                        <img src={previewURL} alt="File preview" className='w-10 h-10 aspect-square object-cover rounded-md' />
+                        ) : null}
                 </Flex>
                 <Flex direction='column' width='100%' className='overflow-hidden whitespace-nowrap gap-0.5'>
                     <Text as="span" size="1" className='overflow-hidden text-ellipsis whitespace-nowrap'>{file.name}</Text>

--- a/frontend/src/hooks/useGetFilePreviewUrl.ts
+++ b/frontend/src/hooks/useGetFilePreviewUrl.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { CustomFile } from '../components/feature/file-upload/FileDrop'
 
 /**
- * Hook takes in a file and returns a blob URL for previewing the file if image
+ * Hook takes in a file and returns a blob URL for previewing the file if image or audio
  * @param file
  * @returns File url
  */
@@ -13,15 +13,15 @@ export const useGetFilePreviewUrl = (file: CustomFile): string => {
     useEffect(() => {
 
         let objectUrl = ""
-        const validImageTypes = ['image/gif', 'image/jpeg', 'image/png', 'image/svg+xml', 'image/webp', 'image/jpg'];
+        const validPreviewTypes = ['image/gif', 'image/jpeg', 'image/png', 'image/svg+xml', 'image/webp', 'image/jpg', 'audio/mpeg', 'audio/mp3', 'audio/m4a'];
 
-        //Only create a URL for images
-        if (validImageTypes.includes(file.type)) {
+        //Only create a URL for images/audios
+        if (validPreviewTypes.includes(file.type)) {
             // create the preview
             objectUrl = URL.createObjectURL(file)
             setUrl(objectUrl)
         } else {
-            setUrl(objectUrl)
+            setUrl("")
         }
 
         // free memory when ever this component is unmounted


### PR DESCRIPTION
This PR adds audio file preview functionality to the FileUploadBox component:

- Supports audio playback (mp3, m4a) with play/pause toggle
- Updates useGetFilePreviewUrl hook to support audio preview types
- Existing image preview functionality is untouched and continues to work as expected


[Screencast from 2025-05-08 08-27-51.webm](https://github.com/user-attachments/assets/84a1035a-bf47-4b0e-9e3a-e0cd86be7708)
