### PR TITLE
feat(ai): file search for AI Agents

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,6 +103,8 @@ const router = createBrowserRouter(
               <Route path=":ID" lazy={() => import('./pages/settings/AI/ViewInstructionTemplate')} />
             </Route>
 
+            <Route path="file-sources" lazy={() => import('./pages/settings/AI/FileSourcesList')} />
+
             <Route path="commands">
               <Route index lazy={() => import('./pages/settings/AI/SavedPromptsList')} />
               <Route path="create" lazy={() => import('./pages/settings/AI/CreateSavedPrompt')} />

--- a/frontend/src/components/feature/settings/ai/bots/BotFileSources.tsx
+++ b/frontend/src/components/feature/settings/ai/bots/BotFileSources.tsx
@@ -1,0 +1,176 @@
+import { Label } from '@/components/common/Form'
+import { HStack, Stack } from '@/components/layout/Stack'
+import { RavenBot } from '@/types/RavenBot/RavenBot'
+import { Badge, Button, Checkbox, Dialog, IconButton, Link as RadixLink, Table, Text } from '@radix-ui/themes'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import FileSourceUploadDialog from '../file-sources/FileSourceUploadDialog'
+import { FiTrash2 } from 'react-icons/fi'
+import { useFrappeGetCall, useFrappeGetDocList } from 'frappe-react-sdk'
+import { TableLoader } from '@/components/layout/Loaders/TableLoader'
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { useState } from 'react'
+
+type Props = {}
+
+const BotFileSources = (props: Props) => {
+
+    const { control } = useFormContext<RavenBot>()
+
+    const { fields, append, remove } = useFieldArray({
+        control,
+        name: "file_sources"
+    })
+
+    const addNew = (id: string) => {
+        append({
+            file: id,
+            name: "",
+            creation: "",
+            modified: "",
+            owner: "",
+            docstatus: 0,
+            modified_by: ""
+        })
+    }
+
+    return (
+        <Stack>
+            <HStack justify='between' align='center'>
+                <Text>Files like manuals, sheets etc can be added to the AI agent as instructions.</Text>
+                <HStack gap='2'>
+                    <FileSourceUploadDialog
+                        buttonProps={{ variant: "soft", className: "not-cal" }}
+                        onUpload={addNew} />
+
+                    <Dialog.Root>
+                        <Dialog.Trigger>
+                            <Button className='not-cal' type='button'>Select Files</Button>
+                        </Dialog.Trigger>
+                        <Dialog.Content>
+                            <Dialog.Title>Select Files</Dialog.Title>
+                            <Dialog.Description size='2'>
+                                Select files from the list below.
+                            </Dialog.Description>
+                            <div className='mt-4'>
+                                <SelectExistingFiles append={addNew} existingFiles={fields.map((d) => d.file)} />
+                            </div>
+                        </Dialog.Content>
+                    </Dialog.Root>
+                </HStack>
+            </HStack>
+
+            <Table.Root variant="surface" className='rounded-sm animate-fadein'>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Type</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {fields?.map((d, index) => (
+                        <FileSourceRow key={d.name} fileID={d.file} onDelete={() => remove(index)} />
+                    ))}
+                </Table.Body>
+            </Table.Root>
+        </Stack>
+    )
+}
+
+const FileSourceRow = ({ fileID, onDelete }: { fileID: string, onDelete: () => void }) => {
+
+    const { data } = useFrappeGetCall('frappe.client.get_value', {
+        doctype: "Raven AI File Source",
+        filters: fileID,
+        fieldname: JSON.stringify(["file_name", "file_type", "file"])
+    }, undefined, {
+        revalidateOnFocus: false
+    })
+
+    const file = data?.message
+
+
+    return <Table.Row className='hover:bg-gray-2 dark:hover:bg-gray-3'>
+        <Table.Cell maxWidth={"250px"}>
+            <RadixLink href={file?.file} target='_blank' color='gray' underline='always' className='text-gray-12'>
+                {file?.file_name}
+            </RadixLink>
+        </Table.Cell>
+        <Table.Cell maxWidth={"250px"}>
+            <Badge color='gray' className='uppercase'>{file?.file_type}</Badge>
+        </Table.Cell>
+        <Table.Cell maxWidth={"80px"} align='right'>
+            <IconButton onClick={onDelete} type='button' color='red' variant='soft' size='1' className='not-cal' title='Delete' aria-label='Delete'>
+                <FiTrash2 />
+            </IconButton>
+        </Table.Cell>
+    </Table.Row>
+}
+
+const SelectExistingFiles = ({ append, existingFiles }: { append: (id: string) => void, existingFiles: string[] }) => {
+
+    const [selectedFiles, setSelectedFiles] = useState<string[]>([])
+
+    const onSelect = (id: string) => {
+        setSelectedFiles((prev) => {
+            if (prev.includes(id)) {
+                return prev.filter((d) => d !== id)
+            }
+            return [...prev, id]
+        })
+    }
+
+    const onSubmit = () => {
+        selectedFiles.forEach((d) => append(d))
+        setSelectedFiles([])
+    }
+
+    const { data, isLoading, error } = useFrappeGetDocList('Raven AI File Source', {
+        fields: ["name", "file_name", "file_type", "file"]
+    }, undefined, {
+        revalidateOnFocus: false
+    })
+
+    return <Stack>
+        {isLoading && <TableLoader columns={2} />}
+        {error && <ErrorBanner error={error} />}
+
+        <Table.Root variant="surface" className='rounded-sm animate-fadein'>
+            <Table.Header>
+                <Table.Row>
+                    <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+                    <Table.ColumnHeaderCell>Type</Table.ColumnHeaderCell>
+
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {data?.map((d) => {
+                    if (existingFiles.includes(d.name)) return null
+                    return <Table.Row key={d.name} className='hover:bg-gray-2 dark:hover:bg-gray-3'>
+                        <Table.Cell maxWidth={"300px"}>
+                            <Label htmlFor={d.name}>
+                                <HStack align='center'>
+                                    <Checkbox id={d.name} checked={selectedFiles.includes(d.name)} onCheckedChange={(checked) => onSelect(d.name)} />
+                                    <Text as='span' size='2' className='text-ellipsis overflow-hidden whitespace-nowrap'>{d.file_name}</Text>
+                                </HStack>
+                            </Label>
+                        </Table.Cell>
+                        <Table.Cell maxWidth={"250px"}><Badge color='gray' className='uppercase'>{d.file_type}</Badge></Table.Cell>
+                    </Table.Row>
+                })}
+            </Table.Body>
+        </Table.Root>
+
+        <HStack justify='end' gap='2' pt='4'>
+            <Dialog.Close>
+                <Button variant='soft' color='gray' type='button' className='not-cal'>Close</Button>
+            </Dialog.Close>
+            <Dialog.Close onClick={onSubmit} disabled={selectedFiles.length === 0}>
+                <Button type='button' className='not-cal'>Add</Button>
+            </Dialog.Close>
+        </HStack>
+    </Stack>
+
+}
+
+export default BotFileSources

--- a/frontend/src/components/feature/settings/ai/bots/BotForm.tsx
+++ b/frontend/src/components/feature/settings/ai/bots/BotForm.tsx
@@ -8,6 +8,7 @@ import BotFunctionsForm from './BotFunctionsForm'
 import { useFormContext } from 'react-hook-form'
 import { RavenBot } from '@/types/RavenBot/RavenBot'
 import BotDocs from './BotDocs'
+import BotFileSources from './BotFileSources'
 
 const ICON_PROPS = {
     size: 18,
@@ -25,6 +26,7 @@ const BotForm = ({ isEdit }: { isEdit: boolean }) => {
                 {isAiBot ? <Tabs.Trigger value='ai'><LuSparkles {...ICON_PROPS} /> AI</Tabs.Trigger> : null}
                 {isAiBot ? <Tabs.Trigger value='instructions'><BiFile {...ICON_PROPS} /> Instructions</Tabs.Trigger> : null}
                 {isAiBot ? <Tabs.Trigger value='functions'><LuSquareFunction {...ICON_PROPS} /> Functions</Tabs.Trigger> : null}
+                {isAiBot ? <Tabs.Trigger value='file-sources'><BiFile {...ICON_PROPS} /> Files</Tabs.Trigger> : null}
                 {isEdit ? <Tabs.Trigger value='api-docs'><BiCode {...ICON_PROPS} /> API Docs</Tabs.Trigger> : null}
             </Tabs.List>
             <Box pt='4'>
@@ -39,6 +41,9 @@ const BotForm = ({ isEdit }: { isEdit: boolean }) => {
                 </Tabs.Content>
                 <Tabs.Content value='functions'>
                     <BotFunctionsForm />
+                </Tabs.Content>
+                <Tabs.Content value='file-sources'>
+                    <BotFileSources />
                 </Tabs.Content>
                 <Tabs.Content value='api-docs'>
                     <BotDocs />

--- a/frontend/src/components/feature/settings/ai/file-sources/FileSourceUploadDialog.tsx
+++ b/frontend/src/components/feature/settings/ai/file-sources/FileSourceUploadDialog.tsx
@@ -1,0 +1,118 @@
+import { ErrorText, Label } from '@/components/common/Form'
+import { CustomFile } from '@/components/feature/file-upload/FileDrop'
+import { FileUploadBox } from '@/components/feature/userSettings/UploadImage/FileUploadBox'
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { HStack, Stack } from '@/components/layout/Stack'
+import { RavenAIFileSource } from '@/types/RavenAI/RavenAIFileSource'
+import { Box, Dialog, Spinner, TextField } from '@radix-ui/themes'
+import { Button } from '@radix-ui/themes'
+import { useFrappeCreateDoc, useFrappeFileUpload } from 'frappe-react-sdk'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+type Props = {
+    mutate: () => void
+}
+
+const FileSourceUploadDialog = ({ mutate }: Props) => {
+
+    const [open, setOpen] = useState(false)
+
+    const onClose = () => {
+        mutate()
+        setOpen(false)
+    }
+
+    return (
+        <Dialog.Root open={open} onOpenChange={setOpen}>
+            <Dialog.Trigger>
+                <Button>Upload</Button>
+            </Dialog.Trigger>
+            <Dialog.Content>
+                <Dialog.Title>Upload File</Dialog.Title>
+                <Dialog.Description size='2'>
+                    Upload a file to use as a data source for AI Agents.
+                </Dialog.Description>
+                <FileSourceUploadForm onClose={onClose} />
+
+
+
+            </Dialog.Content>
+        </Dialog.Root>
+    )
+}
+
+
+const FileSourceUploadForm = ({ onClose }: { onClose: () => void }) => {
+
+    const { register, handleSubmit, formState: { errors }, setValue } = useForm<RavenAIFileSource>()
+
+    const [file, setFile] = useState<CustomFile | undefined>()
+
+    const { upload, loading: uploadLoading, error: uploadError } = useFrappeFileUpload()
+    const { createDoc, loading: createLoading, error: createError } = useFrappeCreateDoc<RavenAIFileSource>()
+
+    const onSubmit = (data: RavenAIFileSource) => {
+        // Upload the file first then create the document
+
+        if (!file) return
+
+        const id = "new-raven-ai-file-source-" + Date.now()
+        upload(file, {
+            doctype: "Raven AI File Source",
+            docname: id,
+            fieldname: "file",
+            isPrivate: true
+        }).then(res => createDoc("Raven AI File Source", {
+            ...data,
+            file: res.file_url,
+        })).then(() => {
+            onClose()
+        })
+    }
+
+    const onFileSelect = (file?: CustomFile) => {
+        if (file) {
+            setFile(file)
+            setValue('file_name', file.name.split('.')[0])
+        } else {
+            setFile(undefined)
+            setValue('file_name', '')
+        }
+    }
+
+    return (
+        <form onSubmit={handleSubmit(onSubmit)}>
+            <Stack gap='4'>
+                {uploadError && <ErrorBanner error={uploadError} />}
+                {createError && <ErrorBanner error={createError} />}
+
+                <FileUploadBox
+                    file={file}
+                    onFileChange={onFileSelect}
+                    hideIfLimitReached
+                    maxFileSize={10}
+                />
+                <Stack>
+                    <Box>
+                        <Label htmlFor='file_name' isRequired>File Name</Label>
+                        <TextField.Root id='file_name' {...register('file_name', {
+                            required: 'File name is required'
+                        })} />
+                    </Box>
+                    {errors.file_name && <ErrorText>{errors.file_name.message}</ErrorText>}
+                </Stack>
+                <HStack justify='end' pt='2'>
+                    <Dialog.Close>
+                        <Button variant='soft' color='gray' className='not-cal'>Cancel</Button>
+                    </Dialog.Close>
+                    <Button type='submit' className='not-cal' disabled={uploadLoading || createLoading}>
+                        {uploadLoading || createLoading ? <Spinner /> : 'Upload'}
+                    </Button>
+                </HStack>
+            </Stack>
+
+        </form>
+    )
+}
+export default FileSourceUploadDialog

--- a/frontend/src/components/feature/settings/ai/file-sources/FileSourceUploadDialog.tsx
+++ b/frontend/src/components/feature/settings/ai/file-sources/FileSourceUploadDialog.tsx
@@ -4,29 +4,30 @@ import { FileUploadBox } from '@/components/feature/userSettings/UploadImage/Fil
 import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
 import { HStack, Stack } from '@/components/layout/Stack'
 import { RavenAIFileSource } from '@/types/RavenAI/RavenAIFileSource'
-import { Box, Dialog, Spinner, TextField } from '@radix-ui/themes'
+import { Box, ButtonProps, Dialog, Spinner, TextField } from '@radix-ui/themes'
 import { Button } from '@radix-ui/themes'
 import { useFrappeCreateDoc, useFrappeFileUpload } from 'frappe-react-sdk'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 
 type Props = {
-    mutate: () => void
+    onUpload: (id: string) => void,
+    buttonProps?: ButtonProps
 }
 
-const FileSourceUploadDialog = ({ mutate }: Props) => {
+const FileSourceUploadDialog = ({ onUpload, buttonProps }: Props) => {
 
     const [open, setOpen] = useState(false)
 
-    const onClose = () => {
-        mutate()
+    const onClose = (id: string) => {
+        onUpload(id)
         setOpen(false)
     }
 
     return (
         <Dialog.Root open={open} onOpenChange={setOpen}>
             <Dialog.Trigger>
-                <Button>Upload</Button>
+                <Button {...buttonProps} type='button'>Upload</Button>
             </Dialog.Trigger>
             <Dialog.Content>
                 <Dialog.Title>Upload File</Dialog.Title>
@@ -34,16 +35,13 @@ const FileSourceUploadDialog = ({ mutate }: Props) => {
                     Upload a file to use as a data source for AI Agents.
                 </Dialog.Description>
                 <FileSourceUploadForm onClose={onClose} />
-
-
-
             </Dialog.Content>
         </Dialog.Root>
     )
 }
 
 
-const FileSourceUploadForm = ({ onClose }: { onClose: () => void }) => {
+const FileSourceUploadForm = ({ onClose }: { onClose: (id: string) => void }) => {
 
     const { register, handleSubmit, formState: { errors }, setValue } = useForm<RavenAIFileSource>()
 
@@ -66,8 +64,8 @@ const FileSourceUploadForm = ({ onClose }: { onClose: () => void }) => {
         }).then(res => createDoc("Raven AI File Source", {
             ...data,
             file: res.file_url,
-        })).then(() => {
-            onClose()
+        })).then((doc) => {
+            onClose(doc.name)
         })
     }
 
@@ -82,37 +80,34 @@ const FileSourceUploadForm = ({ onClose }: { onClose: () => void }) => {
     }
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)}>
-            <Stack gap='4'>
-                {uploadError && <ErrorBanner error={uploadError} />}
-                {createError && <ErrorBanner error={createError} />}
+        <Stack gap='4'>
+            {uploadError && <ErrorBanner error={uploadError} />}
+            {createError && <ErrorBanner error={createError} />}
 
-                <FileUploadBox
-                    file={file}
-                    onFileChange={onFileSelect}
-                    hideIfLimitReached
-                    maxFileSize={10}
-                />
-                <Stack>
-                    <Box>
-                        <Label htmlFor='file_name' isRequired>File Name</Label>
-                        <TextField.Root id='file_name' {...register('file_name', {
-                            required: 'File name is required'
-                        })} />
-                    </Box>
-                    {errors.file_name && <ErrorText>{errors.file_name.message}</ErrorText>}
-                </Stack>
-                <HStack justify='end' pt='2'>
-                    <Dialog.Close>
-                        <Button variant='soft' color='gray' className='not-cal'>Cancel</Button>
-                    </Dialog.Close>
-                    <Button type='submit' className='not-cal' disabled={uploadLoading || createLoading}>
-                        {uploadLoading || createLoading ? <Spinner /> : 'Upload'}
-                    </Button>
-                </HStack>
+            <FileUploadBox
+                file={file}
+                onFileChange={onFileSelect}
+                hideIfLimitReached
+                maxFileSize={10}
+            />
+            <Stack>
+                <Box>
+                    <Label htmlFor='file_name' isRequired>File Name</Label>
+                    <TextField.Root id='file_name' {...register('file_name', {
+                        required: 'File name is required'
+                    })} />
+                </Box>
+                {errors.file_name && <ErrorText>{errors.file_name.message}</ErrorText>}
             </Stack>
-
-        </form>
+            <HStack justify='end' pt='2'>
+                <Dialog.Close>
+                    <Button variant='soft' color='gray' type='button' className='not-cal'>Cancel</Button>
+                </Dialog.Close>
+                <Button type='button' className='not-cal' disabled={uploadLoading || createLoading} onClick={handleSubmit(onSubmit)}>
+                    {uploadLoading || createLoading ? <Spinner /> : 'Upload'}
+                </Button>
+            </HStack>
+        </Stack>
     )
 }
 export default FileSourceUploadDialog

--- a/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
+++ b/frontend/src/components/feature/userSettings/SettingsSidebar.tsx
@@ -40,6 +40,7 @@ export const SettingsSidebar = () => {
                 <SettingsGroup title="AI" icon={BiBot}>
                     <SettingsSidebarItem title="Agents" to='bots' />
                     <SettingsSidebarItem title="Functions" to='functions' />
+                    <SettingsSidebarItem title="File Sources" to='file-sources' />
                     <SettingsSidebarItem title="Instructions" to="instructions" />
                     <SettingsSidebarItem title="Commands" to='commands' />
                     <SettingsSidebarItem title="OpenAI Settings" to='openai-settings' />

--- a/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
+++ b/frontend/src/components/feature/userSettings/UploadImage/FileUploadBox.tsx
@@ -9,6 +9,7 @@ import { CustomFile } from "../../file-upload/FileDrop";
 import { FileUploadProgress } from "../../chat/ChatInput/FileInput/useFileUpload";
 import { getFileSize } from "../../file-upload/FileListItem";
 import { __ } from "@/utils/translations";
+import { FileExtensionIcon } from "@/utils/layout/FileExtIcon";
 
 export type FileUploadBoxProps = FlexProps & {
     /** File to be uploaded */
@@ -127,14 +128,15 @@ const FileItem = ({ file, removeFile, uploadProgress }: FileItemProps) => {
     const progress = uploadProgress?.[file.fileID]?.progress ?? 0
 
     return (
-        <Flex width='100%' gap='2' mt='2' px='4' className='border rounded-md border-slate-8' justify={'between'}>
+        <Flex width='100%' gap='2' mt='2' px='4' py='1' className='border rounded-md border-slate-8' justify={'between'}>
 
             <Flex align='center' justify='center' gap='2'>
                 <Flex align='center' justify='center' className='w-12 h-12'>
-                    {previewURL && <img src={previewURL} alt='File preview' className='w-10 h-10 aspect-square object-cover rounded-md' />}
+                    {previewURL ? <img src={previewURL} alt='File preview' className='w-10 h-10 aspect-square object-cover rounded-md' /> :
+                        <FileExtensionIcon ext={file.name.split('.').pop() ?? ''} size='24' />}
                 </Flex>
                 <Flex direction='column' width='100%' className='overflow-hidden whitespace-nowrap gap-0.5'>
-                    <Text as="span" size="1" className='overflow-hidden text-ellipsis whitespace-nowrap'>{file.name}</Text>
+                    <Text as="span" size="2" className='overflow-hidden text-ellipsis whitespace-nowrap'>{file.name}</Text>
                     <Text size='1' color='gray'>
                         {fileSizeString}
                     </Text>

--- a/frontend/src/pages/settings/AI/FileSourcesList.tsx
+++ b/frontend/src/pages/settings/AI/FileSourcesList.tsx
@@ -6,7 +6,7 @@ import { TableLoader } from '@/components/layout/Loaders/TableLoader'
 import PageContainer from '@/components/layout/Settings/PageContainer'
 import SettingsContentContainer from '@/components/layout/Settings/SettingsContentContainer'
 import SettingsPageHeader from '@/components/layout/Settings/SettingsPageHeader'
-import { HStack } from '@/components/layout/Stack'
+import { HStack, Stack } from '@/components/layout/Stack'
 import { RavenAIFileSource } from '@/types/RavenAI/RavenAIFileSource'
 import { getTimePassed } from '@/utils/dateConversions'
 import { hasRavenAdminRole, isSystemManager } from '@/utils/roles'
@@ -121,16 +121,19 @@ const FileSourceTable = ({ data, mutate }: { data: RavenAIFileSource[], mutate: 
                     <AlertDialog.Description>
                         Are you sure you want to delete the file <strong>{selected?.file_name}</strong>?
                     </AlertDialog.Description>
-                    <HStack justify='end' gap='2' pt='6'>
-                        <AlertDialog.Cancel>
-                            <Button variant='soft' color='gray' className='not-cal'>
-                                Cancel
+                    <Stack gap='2' pt='4'>
+                        {deleteError && <ErrorBanner error={deleteError} />}
+                        <HStack justify='end' gap='2' pt='2'>
+                            <AlertDialog.Cancel>
+                                <Button variant='soft' color='gray' className='not-cal'>
+                                    Cancel
+                                </Button>
+                            </AlertDialog.Cancel>
+                            <Button color='red' className='not-cal' onClick={onDelete} disabled={deleteLoading}>
+                                {deleteLoading ? <Spinner /> : 'Delete'}
                             </Button>
-                        </AlertDialog.Cancel>
-                        <Button color='red' className='not-cal' onClick={onDelete} disabled={deleteLoading}>
-                            {deleteLoading ? <Spinner /> : 'Delete'}
-                        </Button>
-                    </HStack>
+                        </HStack>
+                    </Stack>
                 </AlertDialog.Content>
             </AlertDialog.Root>
         </>

--- a/frontend/src/pages/settings/AI/FileSourcesList.tsx
+++ b/frontend/src/pages/settings/AI/FileSourcesList.tsx
@@ -38,7 +38,7 @@ const FileSourcesList = (props: Props) => {
                 <SettingsPageHeader
                     title='File Sources'
                     description='Add files that can be used by AI Agents.'
-                    actions={isRavenAdmin ? <FileSourceUploadDialog mutate={mutate} /> : undefined}
+                    actions={isRavenAdmin ? <FileSourceUploadDialog onUpload={() => mutate()} /> : undefined}
                 />
                 {isLoading && !error && <TableLoader columns={2} />}
                 <ErrorBanner error={error} />

--- a/frontend/src/pages/settings/AI/FileSourcesList.tsx
+++ b/frontend/src/pages/settings/AI/FileSourcesList.tsx
@@ -1,0 +1,140 @@
+import AINotEnabledCallout from '@/components/feature/settings/ai/AINotEnabledCallout'
+import FileSourceUploadDialog from '@/components/feature/settings/ai/file-sources/FileSourceUploadDialog'
+import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
+import { EmptyState, EmptyStateDescription, EmptyStateIcon, EmptyStateTitle } from '@/components/layout/EmptyState/EmptyListViewState'
+import { TableLoader } from '@/components/layout/Loaders/TableLoader'
+import PageContainer from '@/components/layout/Settings/PageContainer'
+import SettingsContentContainer from '@/components/layout/Settings/SettingsContentContainer'
+import SettingsPageHeader from '@/components/layout/Settings/SettingsPageHeader'
+import { HStack } from '@/components/layout/Stack'
+import { RavenAIFileSource } from '@/types/RavenAI/RavenAIFileSource'
+import { getTimePassed } from '@/utils/dateConversions'
+import { hasRavenAdminRole, isSystemManager } from '@/utils/roles'
+import { AlertDialog, Badge, Button, IconButton, Link as RadixLink, Spinner, Table, Text } from '@radix-ui/themes'
+import { useFrappeDeleteDoc, useFrappeGetDocList } from 'frappe-react-sdk'
+import { useState } from 'react'
+import { BiFile } from 'react-icons/bi'
+import { FiTrash2 } from 'react-icons/fi'
+
+type Props = {}
+
+const FileSourcesList = (props: Props) => {
+
+    const isRavenAdmin = hasRavenAdminRole() || isSystemManager()
+
+    const { data, isLoading, error, mutate } = useFrappeGetDocList<RavenAIFileSource>("Raven AI File Source", {
+        fields: ["name", "file_name", "file", "file_type", "creation"],
+        orderBy: {
+            field: "modified",
+            order: "desc"
+        }
+    }, isRavenAdmin ? undefined : null, {
+        errorRetryCount: 2
+    })
+
+    return (
+        <PageContainer>
+            <SettingsContentContainer>
+                <SettingsPageHeader
+                    title='File Sources'
+                    description='Add files that can be used by AI Agents.'
+                    actions={isRavenAdmin ? <FileSourceUploadDialog mutate={mutate} /> : undefined}
+                />
+                {isLoading && !error && <TableLoader columns={2} />}
+                <ErrorBanner error={error} />
+                <AINotEnabledCallout />
+                {data && data.length > 0 && <FileSourceTable data={data} mutate={mutate} />}
+                {(data?.length === 0 || !isRavenAdmin) && <EmptyState>
+                    <EmptyStateIcon>
+                        <BiFile />
+                    </EmptyStateIcon>
+                    <EmptyStateTitle>File Sources</EmptyStateTitle>
+                    <EmptyStateDescription>
+                        AI Agents can use files as data sources to get more context, read instructions and execute tasks.
+                        You can upload files here and use them across multiple agents.
+                    </EmptyStateDescription>
+                    {isRavenAdmin && <Button asChild className='not-cal'>
+                        Upload a file
+                    </Button>}
+                </EmptyState>}
+            </SettingsContentContainer>
+        </PageContainer>
+    )
+}
+
+const FileSourceTable = ({ data, mutate }: { data: RavenAIFileSource[], mutate: () => void }) => {
+
+    const [selected, setSelected] = useState<RavenAIFileSource | undefined>()
+
+    const { deleteDoc, loading: deleteLoading, error: deleteError } = useFrappeDeleteDoc()
+
+    const onDelete = () => {
+        if (!selected) return
+        deleteDoc("Raven AI File Source", selected.name).then(() => {
+            setSelected(undefined)
+            mutate()
+        })
+    }
+
+    const onOpenChange = (open: boolean) => {
+        if (!open) setSelected(undefined)
+    }
+
+    return (
+        <>
+            <Table.Root variant="surface" className='rounded-sm animate-fadein'>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Type</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell>Uploaded</Table.ColumnHeaderCell>
+                        <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {data?.map((d) => (
+                        <Table.Row key={d.name} className='hover:bg-gray-2 dark:hover:bg-gray-3'>
+                            <Table.Cell maxWidth={"250px"}>
+                                <RadixLink href={d.file} target='_blank' color='gray' underline='always' className='text-gray-12'>
+                                    {d.file_name}
+                                </RadixLink>
+                            </Table.Cell>
+                            <Table.Cell maxWidth={"250px"}>
+                                <Badge color='gray' className='uppercase'>{d.file_type}</Badge>
+                            </Table.Cell>
+                            <Table.Cell maxWidth={"250px"}>
+                                <Text className='line-clamp-1 text-ellipsis'>{getTimePassed(d.creation)}</Text>
+                            </Table.Cell>
+                            <Table.Cell maxWidth={"80px"} align='right'>
+                                <IconButton onClick={() => setSelected(d)} color='red' variant='soft' size='1' className='not-cal' title='Delete' aria-label='Delete'>
+                                    <FiTrash2 />
+                                </IconButton>
+                            </Table.Cell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Table.Root>
+
+            <AlertDialog.Root open={!!selected} onOpenChange={onOpenChange}>
+                <AlertDialog.Content>
+                    <AlertDialog.Title>Delete File?</AlertDialog.Title>
+                    <AlertDialog.Description>
+                        Are you sure you want to delete the file <strong>{selected?.file_name}</strong>?
+                    </AlertDialog.Description>
+                    <HStack justify='end' gap='2' pt='6'>
+                        <AlertDialog.Cancel>
+                            <Button variant='soft' color='gray' className='not-cal'>
+                                Cancel
+                            </Button>
+                        </AlertDialog.Cancel>
+                        <Button color='red' className='not-cal' onClick={onDelete} disabled={deleteLoading}>
+                            {deleteLoading ? <Spinner /> : 'Delete'}
+                        </Button>
+                    </HStack>
+                </AlertDialog.Content>
+            </AlertDialog.Root>
+        </>
+    )
+}
+
+export const Component = FileSourcesList

--- a/frontend/src/types/RavenAI/RavenAIBotFiles.ts
+++ b/frontend/src/types/RavenAI/RavenAIBotFiles.ts
@@ -1,0 +1,15 @@
+
+export interface RavenAIBotFiles{
+	creation: string
+	name: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	File : Link - Raven AI File Source	*/
+	file: string
+}

--- a/frontend/src/types/RavenAI/RavenAIFileSource.ts
+++ b/frontend/src/types/RavenAI/RavenAIFileSource.ts
@@ -1,0 +1,21 @@
+
+export interface RavenAIFileSource{
+	creation: string
+	name: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	File Name : Data	*/
+	file_name?: string
+	/**	File : Attach	*/
+	file: string
+	/**	File Type : Data	*/
+	file_type?: string
+	/**	OpenAI File ID : Data	*/
+	openai_file_id?: string
+}

--- a/frontend/src/types/RavenBot/RavenBot.ts
+++ b/frontend/src/types/RavenBot/RavenBot.ts
@@ -1,4 +1,5 @@
 import { RavenBotFunctions } from '../RavenAI/RavenBotFunctions'
+import { RavenAIBotFiles } from '../RavenAI/RavenAIBotFiles'
 
 export interface RavenBot{
 	creation: string
@@ -49,4 +50,8 @@ File search enables the assistant with knowledge from files that you upload. Onc
 	dynamic_instructions?: 0 | 1
 	/**	Bot Functions : Table - Raven Bot Functions	*/
 	bot_functions?: RavenBotFunctions[]
+	/**	OpenAI Vector Store ID : Data	*/
+	openai_vector_store_id?: string
+	/**	File Sources : Table - Raven AI Bot Files	*/
+	file_sources?: RavenAIBotFiles[]
 }

--- a/raven/ai/ai.py
+++ b/raven/ai/ai.py
@@ -220,11 +220,18 @@ def get_content_attachment_for_file(message_type: str, file_id: str, file_url: s
 	attachments = None
 
 	if message_type == "File":
-		content = f"Uploaded a file. URL of the file is '{file_url}'"
+		content = f"Uploaded a file. URL of the file is '{file_url}'."
+
+		file_extension = file_url.split(".")[-1].lower()
+
+		if file_extension == "pdf":
+			content += (
+				" The file is a PDF. If it's not machine readable, you can extract the text via images."
+			)
 
 		attachments = []
 
-		if file_url.split(".")[-1].lower() in code_interpreter_file_types:
+		if file_extension in code_interpreter_file_types:
 			attachments.append(
 				{
 					"file_id": file_id,
@@ -232,7 +239,7 @@ def get_content_attachment_for_file(message_type: str, file_id: str, file_url: s
 				}
 			)
 
-		if file_url.split(".")[-1].lower() in file_search_file_types:
+		if file_extension in file_search_file_types:
 			attachments.append(
 				{
 					"file_id": file_id,

--- a/raven/ai/ai.py
+++ b/raven/ai/ai.py
@@ -1,7 +1,11 @@
 import frappe
 
 from raven.ai.handler import stream_response
-from raven.ai.openai_client import get_open_ai_client
+from raven.ai.openai_client import (
+	code_interpreter_file_types,
+	file_search_file_types,
+	get_open_ai_client,
+)
 
 
 def handle_bot_dm(message, bot):
@@ -218,21 +222,24 @@ def get_content_attachment_for_file(message_type: str, file_id: str, file_url: s
 	if message_type == "File":
 		content = f"Uploaded a file. URL of the file is '{file_url}'"
 
-		FILE_SEARCH_EXCLUSIONS = [".xlsx", ".csv", ".json", ".xls"]
+		attachments = []
 
-		tool_type = "file_search"
+		if file_url.split(".")[-1].lower() in code_interpreter_file_types:
+			attachments.append(
+				{
+					"file_id": file_id,
+					"tools": [{"type": "code_interpreter"}],
+				}
+			)
 
-		for exclusion in FILE_SEARCH_EXCLUSIONS:
-			if file_url.endswith(exclusion):
-				tool_type = "code_interpreter"
-				break
+		if file_url.split(".")[-1].lower() in file_search_file_types:
+			attachments.append(
+				{
+					"file_id": file_id,
+					"tools": [{"type": "file_search"}],
+				}
+			)
 
-		attachments = [
-			{
-				"file_id": file_id,
-				"tools": [{"type": tool_type}],
-			}
-		]
 	else:
 		content = [
 			{"type": "text", "text": f"Uploaded an image. URL of the image is '{file_url}'"},

--- a/raven/ai/openai_client.py
+++ b/raven/ai/openai_client.py
@@ -30,3 +30,22 @@ def get_openai_models():
 	"""
 	client = get_open_ai_client()
 	return client.models.list()
+
+
+code_interpreter_file_types = [
+	"pdf",
+	"csv",
+	"docx",
+	"doc",
+	"xlsx",
+	"pptx",
+	"txt",
+	"png",
+	"jpg",
+	"jpeg",
+	"md",
+	"json",
+	"html",
+]
+
+file_search_file_types = ["pdf", "csv", "doc", "docx", "json", "txt", "md", "html", "pptx"]

--- a/raven/raven_ai/doctype/raven_ai_bot_files/raven_ai_bot_files.json
+++ b/raven/raven_ai/doctype/raven_ai_bot_files/raven_ai_bot_files.json
@@ -1,0 +1,35 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-10 18:29:14.415518",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "file"
+ ],
+ "fields": [
+  {
+   "fieldname": "file",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "File",
+   "options": "Raven AI File Source",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-05-10 18:29:34.419381",
+ "modified_by": "Administrator",
+ "module": "Raven AI",
+ "name": "Raven AI Bot Files",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/raven/raven_ai/doctype/raven_ai_bot_files/raven_ai_bot_files.py
+++ b/raven/raven_ai/doctype/raven_ai_bot_files/raven_ai_bot_files.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class RavenAIBotFiles(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		file: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.js
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Raven AI File Source", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.json
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.json
@@ -1,0 +1,78 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "hash",
+ "creation": "2025-05-10 16:36:21.445325",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "file_name",
+  "file",
+  "column_break_duoy",
+  "file_type",
+  "openai_file_id"
+ ],
+ "fields": [
+  {
+   "fieldname": "file_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "File Name",
+   "read_only": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "file",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "File",
+   "reqd": 1
+  },
+  {
+   "fieldname": "file_type",
+   "fieldtype": "Data",
+   "label": "File Type",
+   "read_only": 1
+  },
+  {
+   "fieldname": "openai_file_id",
+   "fieldtype": "Data",
+   "label": "OpenAI File ID",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_duoy",
+   "fieldtype": "Column Break"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-05-10 16:48:30.559705",
+ "modified_by": "Administrator",
+ "module": "Raven AI",
+ "name": "Raven AI File Source",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "search_fields": "file_name",
+ "show_title_field_in_link": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "file_name"
+}

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.json
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.json
@@ -48,7 +48,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-10 16:48:30.559705",
+ "modified": "2025-05-12 08:45:43.188440",
  "modified_by": "Administrator",
  "module": "Raven AI",
  "name": "Raven AI File Source",
@@ -64,6 +64,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Raven Admin",
    "share": 1,
    "write": 1
   }

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
@@ -25,7 +25,8 @@ class RavenAIFileSource(Document):
 	def before_validate(self):
 		# Populate file_name and file_type from file
 		if self.file:
-			self.file_name = self.file.split("/")[-1]
+			if not self.file_name:
+				self.file_name = self.file.split("/")[-1]
 			self.file_type = self.file.split(".")[-1]
 
 	def before_insert(self):

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+from raven.ai.openai_client import get_open_ai_client
+
+
+class RavenAIFileSource(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		file: DF.Attach
+		file_name: DF.Data | None
+		file_type: DF.Data | None
+		openai_file_id: DF.Data | None
+	# end: auto-generated types
+
+	def before_validate(self):
+		# Populate file_name and file_type from file
+		if self.file:
+			self.file_name = self.file.split("/")[-1]
+			self.file_type = self.file.split(".")[-1]
+
+	def before_insert(self):
+		self.create_file_in_openai()
+
+	def create_file_in_openai(self):
+		if not self.file:
+			return
+
+		client = get_open_ai_client()
+
+		file_doc = frappe.get_doc("File", {"file_url": self.file})
+		file_path = file_doc.get_full_path()
+
+		response = client.files.create(file=open(file_path, "rb"), purpose="assistants")
+
+		self.openai_file_id = response.id
+
+	def on_trash(self):
+		if self.openai_file_id:
+			client = get_open_ai_client()
+			client.files.delete(self.openai_file_id)

--- a/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
+++ b/raven/raven_ai/doctype/raven_ai_file_source/raven_ai_file_source.py
@@ -45,7 +45,10 @@ class RavenAIFileSource(Document):
 
 		self.openai_file_id = response.id
 
-	def on_trash(self):
+	def after_delete(self):
 		if self.openai_file_id:
-			client = get_open_ai_client()
-			client.files.delete(self.openai_file_id)
+			try:
+				client = get_open_ai_client()
+				client.files.delete(self.openai_file_id)
+			except Exception as e:
+				frappe.log_error(f"Error deleting file from OpenAI: {e}")

--- a/raven/raven_ai/doctype/raven_ai_file_source/test_raven_ai_file_source.py
+++ b/raven/raven_ai/doctype/raven_ai_file_source/test_raven_ai_file_source.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestRavenAIFileSource(UnitTestCase):
+	"""
+	Unit tests for RavenAIFileSource.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestRavenAIFileSource(IntegrationTestCase):
+	"""
+	Integration tests for RavenAIFileSource.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/raven/raven_bot/doctype/raven_bot/raven_bot.json
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.json
@@ -30,7 +30,9 @@
   "section_break_lwkx",
   "instruction",
   "dynamic_instructions",
-  "bot_functions"
+  "bot_functions",
+  "openai_vector_store_id",
+  "file_sources"
  ],
  "fields": [
   {
@@ -174,13 +176,25 @@
    "fieldtype": "Select",
    "label": "Reasoning Effort",
    "options": "low\nmedium\nhigh"
+  },
+  {
+   "fieldname": "file_sources",
+   "fieldtype": "Table",
+   "label": "File Sources",
+   "options": "Raven AI Bot Files"
+  },
+  {
+   "fieldname": "openai_vector_store_id",
+   "fieldtype": "Data",
+   "label": "OpenAI Vector Store ID",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-01 15:40:21.137142",
+ "modified": "2025-05-10 19:07:45.493080",
  "modified_by": "Administrator",
  "module": "Raven Bot",
  "name": "Raven Bot",

--- a/raven/raven_bot/doctype/raven_bot/raven_bot.py
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.py
@@ -8,7 +8,11 @@ from frappe import _
 from frappe.model.document import Document
 from openai import APIConnectionError
 
-from raven.ai.openai_client import get_open_ai_client
+from raven.ai.openai_client import (
+	code_interpreter_file_types,
+	file_search_file_types,
+	get_open_ai_client,
+)
 from raven.utils import get_raven_user
 
 
@@ -257,21 +261,6 @@ class RavenBot(Document):
 		)
 
 		# Some files can be added as a resource for both file search and code interpreter
-		code_interpreter_file_types = [
-			"pdf",
-			"csv",
-			"docx",
-			"doc",
-			"xlsx",
-			"pptx",
-			"txt",
-			"png",
-			"jpg",
-			"jpeg",
-			"md",
-			"json",
-			"html",
-		]
 
 		code_interpreter_files = [
 			f.openai_file_id for f in files if f.file_type.lower() in code_interpreter_file_types
@@ -281,8 +270,6 @@ class RavenBot(Document):
 
 		if code_interpreter_files:
 			tool_resources["code_interpreter"] = {"file_ids": code_interpreter_files}
-
-		file_search_file_types = ["pdf", "csv", "doc", "docx", "json", "txt", "md", "html", "pptx"]
 
 		file_search_files = [
 			f.openai_file_id for f in files if f.file_type.lower() in file_search_file_types

--- a/raven/raven_bot/doctype/raven_bot/raven_bot.py
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.py
@@ -14,8 +14,6 @@ from raven.utils import get_raven_user
 
 class RavenBot(Document):
 	# begin: auto-generated types
-	# ruff: noqa
-
 	# This code is auto-generated. Do not modify anything in this block.
 
 	from typing import TYPE_CHECKING
@@ -23,6 +21,7 @@ class RavenBot(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from raven.raven_ai.doctype.raven_ai_bot_files.raven_ai_bot_files import RavenAIBotFiles
 		from raven.raven_ai.doctype.raven_bot_functions.raven_bot_functions import RavenBotFunctions
 
 		allow_bot_to_write_documents: DF.Check
@@ -33,6 +32,7 @@ class RavenBot(Document):
 		dynamic_instructions: DF.Check
 		enable_code_interpreter: DF.Check
 		enable_file_search: DF.Check
+		file_sources: DF.Table[RavenAIBotFiles]
 		image: DF.AttachImage | None
 		instruction: DF.LongText | None
 		is_ai_bot: DF.Check
@@ -40,9 +40,9 @@ class RavenBot(Document):
 		model: DF.Data | None
 		module: DF.Link | None
 		openai_assistant_id: DF.Data | None
+		openai_vector_store_id: DF.Data | None
 		raven_user: DF.Link | None
 		reasoning_effort: DF.Literal["low", "medium", "high"]
-	# ruff: noqa
 	# end: auto-generated types
 
 	def validate(self):
@@ -127,6 +127,7 @@ class RavenBot(Document):
 				name=self.bot_name,
 				description=self.description or "",
 				tools=self.get_tools_for_assistant(),
+				tool_resources=self.get_tool_resources_for_assistant(),
 				reasoning_effort=reasoning_effort if model.startswith("o") else None,
 			)
 			# Update the tools which were activated for the bot
@@ -168,6 +169,7 @@ class RavenBot(Document):
 				name=self.bot_name,
 				description=self.description or "",
 				tools=self.get_tools_for_assistant(),
+				tool_resources=self.get_tool_resources_for_assistant(),
 				model=model,
 				reasoning_effort=reasoning_effort if model.startswith("o") else None,
 			)
@@ -237,11 +239,116 @@ class RavenBot(Document):
 
 		return tools
 
+	def get_tool_resources_for_assistant(self):
+		if not self.enable_file_search and not self.enable_code_interpreter:
+			return None
+
+		# Check if the bot has any file sources
+		if not self.file_sources:
+			return None
+
+		# Join file sources with Raven AI Bot Files
+		file_source_ids = [f.file for f in self.file_sources]
+
+		files = frappe.get_all(
+			"Raven AI File Source",
+			filters={"name": ["in", file_source_ids]},
+			fields=["file_type", "openai_file_id"],
+		)
+
+		# Some files can be added as a resource for both file search and code interpreter
+		code_interpreter_file_types = [
+			"pdf",
+			"csv",
+			"docx",
+			"doc",
+			"xlsx",
+			"pptx",
+			"txt",
+			"png",
+			"jpg",
+			"jpeg",
+			"md",
+			"json",
+			"html",
+		]
+
+		code_interpreter_files = [
+			f.openai_file_id for f in files if f.file_type.lower() in code_interpreter_file_types
+		]
+
+		tool_resources = {}
+
+		if code_interpreter_files:
+			tool_resources["code_interpreter"] = {"file_ids": code_interpreter_files}
+
+		file_search_file_types = ["pdf", "csv", "doc", "docx", "json", "txt", "md", "html", "pptx"]
+
+		file_search_files = [
+			f.openai_file_id for f in files if f.file_type.lower() in file_search_file_types
+		]
+
+		# Create a vector store for the assistant if it doesn't exist. Else update the existing vector store
+
+		if file_search_files:
+			if not self.openai_vector_store_id:
+				self.create_vector_store(file_search_files)
+			else:
+				self.update_vector_store(file_search_files)
+
+			tool_resources["file_search"] = {"vector_store_ids": [self.openai_vector_store_id]}
+
+		# Check if the tool resources are empty
+		if tool_resources.get("file_search") or tool_resources.get("code_interpreter"):
+			return tool_resources
+		else:
+			return None
+
+	def create_vector_store(self, file_ids: list[str]):
+		# Create a new vector store for the assistant
+		client = get_open_ai_client()
+		vector_store = client.vector_stores.create(
+			name=self.name,
+			file_ids=file_ids,
+		)
+
+		self.openai_vector_store_id = vector_store.id
+
+	def update_vector_store(self, file_ids: list[str]):
+		# Update the vector store for the assistant
+		client = get_open_ai_client()
+
+		existing_vector_store_files = client.vector_stores.files.list(
+			vector_store_id=self.openai_vector_store_id, limit=100
+		)
+
+		existing_vector_store_file_ids = [f.id for f in existing_vector_store_files.data]
+
+		deleted_files = [f for f in existing_vector_store_file_ids if f not in file_ids]
+
+		added_files = [f for f in file_ids if f not in existing_vector_store_file_ids]
+
+		if added_files:
+			vector_store_file_batch = client.vector_stores.file_batches.create(
+				vector_store_id=self.openai_vector_store_id,
+				file_ids=added_files,
+			)
+
+		if deleted_files:
+			for file_id in deleted_files:
+				client.vector_stores.files.delete(
+					vector_store_id=self.openai_vector_store_id,
+					file_id=file_id,
+				)
+
 	def delete_openai_assistant(self):
 		# Delete the OpenAI Assistant for the bot
+		# Delete the vector store for the assistant
 		try:
 			client = get_open_ai_client()
 			client.beta.assistants.delete(self.openai_assistant_id)
+			if self.openai_vector_store_id:
+				client.vector_stores.delete(self.openai_vector_store_id)
 		except Exception:
 			frappe.log_error(
 				f"Error deleting OpenAI Assistant {self.openai_assistant_id} for bot {self.name}"


### PR DESCRIPTION
AI Agents can now accept files like HR Manuals, Spreadsheets and images for instructions. Based on the type of file, the AI Agent can either use ["File Search"](https://platform.openai.com/docs/assistants/tools/file-search) or ["Code Interpreter"](https://platform.openai.com/docs/assistants/tools/code-interpreter) on it.

Another improvement: earlier, in chats, the AI Agent could not parse PDFs which were not machine readable - like scans of invoices. With this new update, certain attachments are made available to both code interpreter as well as file search.

![CleanShot 2025-05-12 at 10 18 31@2x](https://github.com/user-attachments/assets/79f058af-829b-45a8-830b-2760f05e4d62)
![CleanShot 2025-05-12 at 10 18 46@2x](https://github.com/user-attachments/assets/5e63253b-522e-49f3-be93-0ff5366bb54c)
