### PR TITLE
fix: add unique constraint to reactions to avoid race conditions

### DIFF
--- a/frontend/src/utils/operations.ts
+++ b/frontend/src/utils/operations.ts
@@ -81,25 +81,33 @@ export const getUsers = (usersList: string[], count: number, currentUser: string
 
             if (currentUserInList) {
                 const otherUsers = usersList.filter((user, index) => index !== currentUserIndex)
-
-                // Show all users upto 50
-                const userString = otherUsers.slice(0, 50).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
-
                 const remainingUsers = otherUsers.length - 50
                 if (remainingUsers > 0) {
+                    // Show all users upto 50
+                    const userString = otherUsers.slice(0, 50).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
                     return `You, ${userString} and ${remainingUsers} others`
                 } else {
-                    return `You and ${userString}`
+                    // The user string will need to have an ", and" just before the last user
+                    // For example, You, John, Jane, and Henry
+                    const numberOfUsers = otherUsers.length
+                    const userString = otherUsers.slice(0, numberOfUsers - 1).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
+                    const lastUser = userArray.find((u) => u.name == otherUsers[numberOfUsers - 1])?.full_name
+                    return `You, ${userString}, and ${lastUser}`
                 }
             }
             else {
-                const userString = usersList.slice(0, 50).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
-                const remainingUsers = usersList.length - 50
+                const numberOfUsers = usersList.length
 
-                if (remainingUsers > 0) {
+                if (numberOfUsers > 50) {
+                    const userString = usersList.slice(0, 50).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
+                    const remainingUsers = usersList.length - 50
                     return `${userString} and ${remainingUsers} others`
                 } else {
-                    return userString
+                    // The user string will need to have an ", and" just before the last user
+                    // For example, John, Jane, and Henry
+                    const userString = usersList.slice(0, numberOfUsers - 1).map((user) => userArray.find((u) => u.name == user)?.full_name).join(', ')
+                    const lastUser = userArray.find((u) => u.name == usersList[numberOfUsers - 1])?.full_name
+                    return `${userString} and ${lastUser}`
                 }
             }
         }

--- a/raven/patches.txt
+++ b/raven/patches.txt
@@ -10,3 +10,4 @@ raven.patches.v1_6.migrate_older_raven_users #2
 raven.patches.v2_0.migrate_existing_dm_threads
 raven.patches.v2_0.create_default_workspace
 raven.patches.v2_0.create_default_company_workspace_mapping
+raven.patches.v2_4.add_unique_constraint_on_reactions #2

--- a/raven/patches/v2_4/add_unique_constraint_on_reactions.py
+++ b/raven/patches/v2_4/add_unique_constraint_on_reactions.py
@@ -1,0 +1,61 @@
+import frappe
+
+from raven.api.reactions import calculate_message_reaction
+from raven.raven_messaging.doctype.raven_message_reaction.raven_message_reaction import (
+	on_doctype_update,
+)
+
+
+def execute():
+	"""
+	Add a unique constraint on Raven Message Reaction on the message, owner and reaction_escaped fields
+	"""
+
+	# Before adding the constraint, we need to delete any existing reactions where the message, owner and reaction_escaped fields are the same
+
+	# For this, we can count the number of reactions where the message, owner and reaction_escaped fields are the same
+	duplicate_reactions = frappe.db.sql(
+		"""
+		SELECT
+			message,
+			owner,
+			reaction_escaped,
+			COUNT(*) AS count
+		FROM
+			`tabRaven Message Reaction`
+		GROUP BY
+			message,
+			owner,
+			reaction_escaped
+		HAVING
+			COUNT(*) > 1
+		""",
+		as_dict=True,
+	)
+	messages_to_be_updated = set()
+
+	for reaction in duplicate_reactions:
+		if reaction.count == 1:
+			continue
+		reaction_ids = frappe.db.get_all(
+			"Raven Message Reaction",
+			filters={
+				"message": reaction.message,
+				"owner": reaction.owner,
+				"reaction_escaped": reaction.reaction_escaped,
+			},
+			fields=["name"],
+		)
+		# Delete all but the first one
+		for reaction_id in reaction_ids[1:]:
+			frappe.delete_doc("Raven Message Reaction", reaction_id.name, delete_permanently=True)
+
+			# Update the count for the reaction
+		messages_to_be_updated.add(reaction.message)
+
+		# Update the count for the reactions
+	for message in messages_to_be_updated:
+		calculate_message_reaction(message_id=message, do_not_publish=True)
+
+	# Add the unique constraint
+	on_doctype_update()

--- a/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.py
+++ b/raven/raven_messaging/doctype/raven_message_reaction/raven_message_reaction.py
@@ -4,6 +4,7 @@
 import json
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from raven.api.reactions import calculate_message_reaction
@@ -32,3 +33,11 @@ class RavenMessageReaction(Document):
 	def after_delete(self):
 		# Update the count for the current reaction
 		calculate_message_reaction(self.message, self.channel_id)
+
+
+def on_doctype_update():
+	frappe.db.add_unique(
+		"Raven Message Reaction",
+		fields=["message", "owner", "reaction_escaped"],
+		constraint_name="unique_reaction",
+	)


### PR DESCRIPTION
Closes #1697 

When reacting to a message very quickly, the system was registering multiple reactions on the same message by the same user. 

The fix includes:
1. A unique constraint on three fields - owner, message and reaction in Raven Message Reaction
2. A patch that would add the constraint to existing sites + also remove duplicate reactions from messages before adding the constraint (else the patch would fail)
3. When reacting to a message, we first try inserting it - if it fails due to a unique validation error, we remove the reaction - this ensures atomicity (as opposed to first checking if a reaction exists and then deciding it)
4. When deleting a reaction, we now delete all reactions matching the criteria instead of just one like earlier.
5. When computing the final JSON to be stored in the message, only unique users are considered.

4 & 5 don't matter now since we have a unique constraint at the db level.