### PR TITLE
fix: publish realtime events to room for Raven instead of "all"

### DIFF
--- a/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
+++ b/raven/raven_channel_management/doctype/raven_channel/raven_channel.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
-from raven.utils import delete_channel_members_cache
+from raven.utils import delete_channel_members_cache, get_raven_room
 
 
 class RavenChannel(Document):
@@ -62,7 +62,7 @@ class RavenChannel(Document):
 				{
 					"channel_id": self.name,
 				},
-				room="all",
+				room=get_raven_room(),
 				after_commit=True,
 			)
 
@@ -93,7 +93,7 @@ class RavenChannel(Document):
 				{
 					"channel_id": self.name,
 				},
-				room="all",
+				room=get_raven_room(),
 				after_commit=True,
 			)
 
@@ -118,7 +118,7 @@ class RavenChannel(Document):
 					{
 						"channel_id": self.name,
 					},
-					room="all",
+					room=get_raven_room(),
 					after_commit=True,
 				)
 

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -17,7 +17,7 @@ from raven.notification import (
 	send_notification_to_topic,
 	send_notification_to_user,
 )
-from raven.utils import refresh_thread_reply_count, track_channel_visit
+from raven.utils import get_raven_room, refresh_thread_reply_count, track_channel_visit
 
 
 class RavenMessage(Document):
@@ -339,7 +339,7 @@ class RavenMessage(Document):
 					"number_of_replies": reply_count,
 				},
 				after_commit=True,
-				room="all",
+				room=get_raven_room(),
 			)
 		else:
 			# This event needs to be published to all users on Raven (desk + website)
@@ -354,7 +354,7 @@ class RavenMessage(Document):
 					"last_message_timestamp": self.creation,
 				},
 				after_commit=True,
-				room="all",
+				room=get_raven_room(),
 			)
 
 	def send_push_notification(self):

--- a/raven/utils.py
+++ b/raven/utils.py
@@ -3,6 +3,16 @@ import frappe
 from raven.notification import clear_push_tokens_for_channel_cache
 
 
+def get_raven_room():
+	"""
+	Room which any user with the role "Raven User" is subscribed to.
+	"""
+	# When they open the app, the will be subscribed to the users list.
+	# We are just using the doctype room to send events to them
+	# If we use "all" instead, then the events are only sent to System Users and not users who do not have Desk access.
+	return "doctype:Raven User"
+
+
 def track_channel_visit(channel_id, user=None, commit=False, publish_event_for_user=False):
 	"""
 	Track the last visit of the user to the channel.
@@ -142,7 +152,7 @@ def delete_channel_members_cache(channel_id: str, clear_push_tokens=True):
 	frappe.publish_realtime(
 		"channel_members_updated",
 		{"channel_id": channel_id},
-		room="all",
+		room=get_raven_room(),
 		after_commit=True,
 	)
 


### PR DESCRIPTION
Scenario:
User has the role "Raven User", but does not have access to the desk interface - hence is a "Website User".
Events that were being published to the room "all" were not being broadcasted to website users. This meant that thread reply counts, unread message counts, channel member updates were all being missed.

Fix:
Just send all events to the "doctype:Raven User" room (meant for list_update in Frappe Framework). Since all users are going to be subscribed to that room on app load anyway, it does not hurt. Seems to be working.