### PR TITLE
fix: Handling of Single Quotes in Scheduled Bot Message Content

### DIFF
--- a/raven/raven_integrations/doctype/raven_scheduler_event/raven_scheduler_event.py
+++ b/raven/raven_integrations/doctype/raven_scheduler_event/raven_scheduler_event.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2024, The Commit Company and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
 from frappe.model.document import Document
-import json
 
 
 class RavenSchedulerEvent(Document):


### PR DESCRIPTION
Issue: When the scheduled bot message content contained single quotes ('), the generated Python code for the server script became invalid, resulting in syntax errors and failed scheduled events.

Solution:
Updated the code to use `json.dumps(self.content)` when generating the server script.
This ensures that single quotes, double quotes, and newlines in the message content are properly escaped, making the generated script always valid Python.

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/f9466a48-fe31-4f2f-91f8-5ff450cc3cee" />

After fix, send message:
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/da4ea6c8-164e-4a4b-9553-c20175bc3227" />
