### PR TITLE
feat(ai): add new standard functions get_value and set_value

### DIFF
--- a/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
@@ -24,6 +24,12 @@ export const FUNCTION_TYPES = [
         type: "Standard"
     },
     {
+        value: "Set Value",
+        description: "Set a value in a document in the system. This function can set a single value or multiple values in a document.",
+        requires_write_permissions: true,
+        type: "Standard"
+    },
+    {
         value: "Create Document",
         description: "Create any document in the system.",
         requires_write_permissions: true,

--- a/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
@@ -18,6 +18,12 @@ export const FUNCTION_TYPES = [
         type: "Standard"
     },
     {
+        value: "Get Value",
+        description: "Get a single value or multiple values from a document in the system using filters.",
+        requires_write_permissions: false,
+        type: "Standard"
+    },
+    {
         value: "Create Document",
         description: "Create any document in the system.",
         requires_write_permissions: true,

--- a/frontend/src/components/feature/settings/ai/functions/FunctionForm.tsx
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionForm.tsx
@@ -278,7 +278,7 @@ const ReferenceDoctypeField = () => {
 
     const type = watch('type')
 
-    const DOCUMENT_REF_FUNCTIONS = ["Get Document", "Get Multiple Documents", "Get List", "Get Value", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document"]
+    const DOCUMENT_REF_FUNCTIONS = ["Get Document", "Get Multiple Documents", "Get List", "Get Value", "Set Value", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document"]
 
     const onReferenceDoctypeChange = (e: ChangeEvent<HTMLInputElement>) => {
 

--- a/frontend/src/components/feature/settings/ai/functions/FunctionForm.tsx
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionForm.tsx
@@ -278,7 +278,7 @@ const ReferenceDoctypeField = () => {
 
     const type = watch('type')
 
-    const DOCUMENT_REF_FUNCTIONS = ["Get Document", "Get Multiple Documents", "Get List", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document"]
+    const DOCUMENT_REF_FUNCTIONS = ["Get Document", "Get Multiple Documents", "Get List", "Get Value", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document"]
 
     const onReferenceDoctypeChange = (e: ChangeEvent<HTMLInputElement>) => {
 
@@ -299,6 +299,14 @@ const ReferenceDoctypeField = () => {
             if (type === 'Get List') {
                 description = `This function fetches a list of ${e.target.value} from the system.`
                 function_name = `get_${e.target.value.toLowerCase().replace(/\s/g, '_')}_list`
+            }
+            if (type === 'Get Value') {
+                description = `This function fetches a value from a ${e.target.value} in the system.`
+                function_name = `get_${e.target.value.toLowerCase().replace(/\s/g, '_')}_value`
+            }
+            if (type === 'Set Value') {
+                description = `This function sets a value in a ${e.target.value} in the system.`
+                function_name = `set_${e.target.value.toLowerCase().replace(/\s/g, '_')}_value`
             }
             if (type === 'Create Document') {
                 description = `This function creates a ${e.target.value} in the system.`

--- a/frontend/src/types/RavenAI/RavenAIFunction.ts
+++ b/frontend/src/types/RavenAI/RavenAIFunction.ts
@@ -18,7 +18,7 @@ export interface RavenAIFunction{
 	/**	Function Path : Small Text	*/
 	function_path?: string
 	/**	Type : Select	*/
-	type: "Get Document" | "Get Multiple Documents" | "Get List" | "Create Document" | "Create Multiple Documents" | "Update Document" | "Update Multiple Documents" | "Delete Document" | "Delete Multiple Documents" | "Submit Document" | "Cancel Document" | "Get Amended Document" | "Custom Function" | "Send Message" | "Attach File to Document" | "Get Report Result"
+	type: "Get Document" | "Get Multiple Documents" | "Get List" | "Get Value" | "Set Value" | "Create Document" | "Create Multiple Documents" | "Update Document" | "Update Multiple Documents" | "Delete Document" | "Delete Multiple Documents" | "Submit Document" | "Cancel Document" | "Get Amended Document" | "Custom Function" | "Send Message" | "Attach File to Document" | "Get Report Result"
 	/**	Reference DocType : Link - DocType	*/
 	reference_doctype?: string
 	/**	Pass parameters as JSON : Check - If checked, the params will be passed as a JSON object instead of named parameters	*/

--- a/packages/types/types/RavenAI/RavenAIFunction.ts
+++ b/packages/types/types/RavenAI/RavenAIFunction.ts
@@ -1,5 +1,5 @@
 
-export interface RavenAIFunction {
+export interface RavenAIFunction{
 	name: string
 	creation: string
 	modified: string
@@ -17,7 +17,7 @@ export interface RavenAIFunction {
 	/**	Function Path : Small Text	*/
 	function_path?: string
 	/**	Type : Select	*/
-	type: "Get Document" | "Get Multiple Documents" | "Get List" | "Create Document" | "Create Multiple Documents" | "Update Document" | "Update Multiple Documents" | "Delete Document" | "Delete Multiple Documents" | "Submit Document" | "Cancel Document" | "Get Amended Document" | "Custom Function" | "Send Message" | "Attach File to Document" | "Get Report Result" | "Get Value"
+	type: "Get Document" | "Get Multiple Documents" | "Get List" | "Create Document" | "Create Multiple Documents" | "Update Document" | "Update Multiple Documents" | "Delete Document" | "Delete Multiple Documents" | "Submit Document" | "Cancel Document" | "Get Amended Document" | "Custom Function" | "Send Message" | "Attach File to Document" | "Get Report Result" | "Get Value" | "Set Value"
 	/**	Reference DocType : Link - DocType	*/
 	reference_doctype?: string
 	/**	Pass parameters as JSON : Check - If checked, the params will be passed as a JSON object instead of named parameters	*/

--- a/packages/types/types/RavenAI/RavenAIFunction.ts
+++ b/packages/types/types/RavenAI/RavenAIFunction.ts
@@ -1,0 +1,35 @@
+
+export interface RavenAIFunction {
+	name: string
+	creation: string
+	modified: string
+	owner: string
+	modified_by: string
+	docstatus: 0 | 1 | 2
+	parent?: string
+	parentfield?: string
+	parenttype?: string
+	idx?: number
+	/**	Function Name : Data	*/
+	function_name: string
+	/**	Description : Small Text	*/
+	description: string
+	/**	Function Path : Small Text	*/
+	function_path?: string
+	/**	Type : Select	*/
+	type: "Get Document" | "Get Multiple Documents" | "Get List" | "Create Document" | "Create Multiple Documents" | "Update Document" | "Update Multiple Documents" | "Delete Document" | "Delete Multiple Documents" | "Submit Document" | "Cancel Document" | "Get Amended Document" | "Custom Function" | "Send Message" | "Attach File to Document" | "Get Report Result" | "Get Value"
+	/**	Reference DocType : Link - DocType	*/
+	reference_doctype?: string
+	/**	Pass parameters as JSON : Check - If checked, the params will be passed as a JSON object instead of named parameters	*/
+	pass_parameters_as_json?: 0 | 1
+	/**	Requires Write Permissions : Check	*/
+	requires_write_permissions?: 0 | 1
+	/**	Strict : Check	*/
+	strict?: 0 | 1
+	/**	Parameters : Table - Raven AI Function Params	*/
+	parameters?: any
+	/**	Params : JSON	*/
+	params?: any
+	/**	Function Definition : JSON	*/
+	function_definition?: any
+}

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -210,42 +210,45 @@ def get_list(doctype: str, filters: dict = None, fields: list = None, limit: int
 	# Use the frappe.get_list method to get the list of documents
 	return frappe.get_list(doctype, filters=filters, fields=filtered_fields, limit=limit)
 
+
 def get_value(doctype: str, filters: dict = None, fieldname: str | list = "name"):
 	"""
 	Returns a value from a document
 
-		:param doctype: DocType to be queried
-		:param fieldname: Field to be returned (default `name`) - can be a list of fields(str) or a single field(str)
-		:param filters: dict or string for identifying the record
+	        :param doctype: DocType to be queried
+	        :param fieldname: Field to be returned (default `name`) - can be a list of fields(str) or a single field(str)
+	        :param filters: dict or string for identifying the record
 	"""
 	meta = frappe.get_meta(doctype)
-	
+
 	if isinstance(fieldname, list):
 		for field in fieldname:
 			if not meta.has_field(field):
 				return {"message": f"Field {field} does not exist in {doctype}"}
-		
+
 		return frappe.db.get_value(doctype, filters, fieldname)
 	else:
 		if not meta.has_field(fieldname):
 			return {"message": f"Field {fieldname} does not exist in {doctype}"}
-		
+
 		return frappe.db.get_value(doctype, filters, fieldname)
-	
+
+
 def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str = None):
 	"""
 	Set a value in a document
 
-		:param doctype: DocType to be queried
-		:param document_id: Document ID to be updated
-		:param fieldname: Field to be updated - fieldname string or JSON / dict with key value pair
-		:param value: value if fieldname is JSON
+	        :param doctype: DocType to be queried
+	        :param document_id: Document ID to be updated
+	        :param fieldname: Field to be updated - fieldname string or JSON / dict with key value pair
+	        :param value: value if fieldname is JSON
 
-		Example:
-			frappe.db.set_value("Customer", "CUST-00001", {"customer_name": "John Doe", "customer_email": "john.doe@example.com"}) OR
-			frappe.db.set_value("Customer", "CUST-00001", "customer_name", "John Doe")
+	        Example:
+	                frappe.db.set_value("Customer", "CUST-00001", {"customer_name": "John Doe", "customer_email": "john.doe@example.com"}) OR
+	                frappe.db.set_value("Customer", "CUST-00001", "customer_name", "John Doe")
 	"""
 	if isinstance(fieldname, dict):
 		return frappe.db.set_value(doctype, document_id, fieldname)
 	else:
 		return frappe.db.set_value(doctype, document_id, fieldname, value)
+

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -209,3 +209,25 @@ def get_list(doctype: str, filters: dict = None, fields: list = None, limit: int
 
 	# Use the frappe.get_list method to get the list of documents
 	return frappe.get_list(doctype, filters=filters, fields=filtered_fields, limit=limit)
+
+def get_value(doctype: str, filters: dict = None, fieldname: str | list = "name"):
+	"""
+	Returns a value from a document
+
+		:param doctype: DocType to be queried
+		:param fieldname: Field to be returned (default `name`) - can be a list of fields(str) or a single field(str)
+		:param filters: dict or string for identifying the record
+	"""
+	meta = frappe.get_meta(doctype)
+	
+	if isinstance(fieldname, list):
+		for field in fieldname:
+			if not meta.has_field(field):
+				return {"message": f"Field {field} does not exist in {doctype}"}
+		
+		return frappe.db.get_value(doctype, filters, fieldname)
+	else:
+		if not meta.has_field(fieldname):
+			return {"message": f"Field {fieldname} does not exist in {doctype}"}
+		
+		return frappe.db.get_value(doctype, filters, fieldname)

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -226,12 +226,12 @@ def get_value(doctype: str, filters: dict = None, fieldname: str | list = "name"
 			if not meta.has_field(field):
 				return {"message": f"Field {field} does not exist in {doctype}"}
 
-		return frappe.db.get_value(doctype, filters, fieldname)
+		return client.get_value(doctype, filters=filters, fieldname=fieldname)
 	else:
 		if not meta.has_field(fieldname):
 			return {"message": f"Field {fieldname} does not exist in {doctype}"}
 
-		return frappe.db.get_value(doctype, filters, fieldname)
+		return client.get_value(doctype, filters=filters, fieldname=fieldname)
 
 
 def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str = None):
@@ -244,11 +244,10 @@ def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str 
 	        :param value: value if fieldname is JSON
 
 	        Example:
-	                frappe.db.set_value("Customer", "CUST-00001", {"customer_name": "John Doe", "customer_email": "john.doe@example.com"}) OR
-	                frappe.db.set_value("Customer", "CUST-00001", "customer_name", "John Doe")
+	                client.set_value("Customer", "CUST-00001", {"customer_name": "John Doe", "customer_email": "john.doe@example.com"}) OR
+	                client.set_value("Customer", "CUST-00001", "customer_name", "John Doe")
 	"""
 	if isinstance(fieldname, dict):
-		return frappe.db.set_value(doctype, document_id, fieldname)
+		return client.set_value(doctype, document_id, fieldname)
 	else:
-		return frappe.db.set_value(doctype, document_id, fieldname, value)
-
+		return client.set_value(doctype, document_id, fieldname, value)

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -231,3 +231,21 @@ def get_value(doctype: str, filters: dict = None, fieldname: str | list = "name"
 			return {"message": f"Field {fieldname} does not exist in {doctype}"}
 		
 		return frappe.db.get_value(doctype, filters, fieldname)
+	
+def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str = None):
+	"""
+	Set a value in a document
+
+		:param doctype: DocType to be queried
+		:param document_id: Document ID to be updated
+		:param fieldname: Field to be updated - fieldname string or JSON / dict with key value pair
+		:param value: value if fieldname is JSON
+
+		Example:
+			frappe.db.set_value("Customer", "CUST-00001", {"customer_name": "John Doe", "customer_email": "john.doe@example.com"}) OR
+			frappe.db.set_value("Customer", "CUST-00001", "customer_name", "John Doe")
+	"""
+	if isinstance(fieldname, dict):
+		return frappe.db.set_value(doctype, document_id, fieldname)
+	else:
+		return frappe.db.set_value(doctype, document_id, fieldname, value)

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -20,6 +20,7 @@ from raven.ai.functions import (
 	submit_document,
 	update_document,
 	update_documents,
+	get_value,
 )
 from raven.ai.openai_client import get_open_ai_client
 
@@ -281,6 +282,14 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							filters=args.get("filters"),
 							fields=args.get("fields"),
 							limit=args.get("limit", 20),
+						)
+					
+					if function.type == "Get Value":
+						self.publish_event(f"Fetching value for {function.reference_doctype}...")
+						function_output = get_value(
+							doctype=function.reference_doctype,
+							filters=args.get("filters"),
+							fieldname=args.get("fieldname"),
 						)
 
 					tool_outputs.append(

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -21,6 +21,7 @@ from raven.ai.functions import (
 	update_document,
 	update_documents,
 	get_value,
+	set_value,
 )
 from raven.ai.openai_client import get_open_ai_client
 
@@ -292,6 +293,14 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							fieldname=args.get("fieldname"),
 						)
 
+					if function.type == "Set Value":
+						self.publish_event(f"Setting value for {function.reference_doctype}...")
+						function_output = set_value(
+							doctype=function.reference_doctype,
+							document_id=args.get("document_id"),
+							fieldname=args.get("fieldname"),
+							value=args.get("value"),
+						)
 					tool_outputs.append(
 						{"tool_call_id": tool.id, "output": json.dumps(function_output, default=str)}
 					)

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -17,11 +17,11 @@ from raven.ai.functions import (
 	get_document,
 	get_documents,
 	get_list,
+	get_value,
+	set_value,
 	submit_document,
 	update_document,
 	update_documents,
-	get_value,
-	set_value,
 )
 from raven.ai.openai_client import get_open_ai_client
 
@@ -284,7 +284,7 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							fields=args.get("fields"),
 							limit=args.get("limit", 20),
 						)
-					
+
 					if function.type == "Get Value":
 						self.publish_event(f"Fetching value for {function.reference_doctype}...")
 						function_output = get_value(

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.json
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.json
@@ -48,7 +48,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "Get Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nSend Message\nAttach File to Document\nGet Report Result",
+"options": "Get Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nSend Message\nAttach File to Document\nGet Report Result\nGet Value",
    "reqd": 1
   },
   {
@@ -102,11 +102,10 @@
    "fieldtype": "Check",
    "label": "Strict"
   }
- ],
- "grid_page_length": 50,
+],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-05-18 17:42:22.628503",
+"modified": "2025-05-30 13:38:52.127247",
  "modified_by": "Administrator",
  "module": "Raven AI",
  "name": "Raven AI Function",
@@ -137,8 +136,7 @@
    "share": 1,
    "write": 1
   }
- ],
- "row_format": "Dynamic",
+],
  "search_fields": "description",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.json
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.json
@@ -48,7 +48,7 @@
    "fieldname": "type",
    "fieldtype": "Select",
    "label": "Type",
-"options": "Get Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nSend Message\nAttach File to Document\nGet Report Result\nGet Value",
+   "options": "Get Document\nGet Multiple Documents\nGet List\nCreate Document\nCreate Multiple Documents\nUpdate Document\nUpdate Multiple Documents\nDelete Document\nDelete Multiple Documents\nSubmit Document\nCancel Document\nGet Amended Document\nCustom Function\nSend Message\nAttach File to Document\nGet Report Result\nGet Value\nSet Value",
    "reqd": 1
   },
   {
@@ -102,10 +102,10 @@
    "fieldtype": "Check",
    "label": "Strict"
   }
-],
+ ],
  "index_web_pages_for_search": 1,
  "links": [],
-"modified": "2025-05-30 13:38:52.127247",
+ "modified": "2025-06-06 12:57:13.241374",
  "modified_by": "Administrator",
  "module": "Raven AI",
  "name": "Raven AI Function",
@@ -136,7 +136,7 @@
    "share": 1,
    "write": 1
   }
-],
+ ],
  "search_fields": "description",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -28,7 +28,7 @@ class RavenAIFunction(Document):
 		reference_doctype: DF.Link | None
 		requires_write_permissions: DF.Check
 		strict: DF.Check
-		type: DF.Literal["Get Document", "Get Multiple Documents", "Get List", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document", "Custom Function", "Send Message", "Attach File to Document", "Get Report Result", "Get Value"]
+		type: DF.Literal["Get Document", "Get Multiple Documents", "Get List", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document", "Custom Function", "Send Message", "Attach File to Document", "Get Report Result", "Get Value", "Set Value"]
 	# end: auto-generated types
 
 	def before_validate(self):
@@ -276,6 +276,33 @@ class RavenAIFunction(Document):
 					},
 				},
 				"required": ["doctype", "filters", "fieldname"],
+				"additionalProperties": False,
+			}
+		elif self.type == "Set Value":
+			params = {
+				"type": "object",
+				"properties": {
+					"doctype": {
+						"type": "string",
+						"description": "The DocType to set the value for",
+					},
+					"document_id": {
+						"type": "string",
+						"description": "The ID of the document to set the value for",
+					},
+					"fieldname": {
+						"anyOf": [
+							{"type": "string"},
+							{"type": "object", "additionalProperties": True}
+						],
+						"description": "The fields whose value needs to be set. Can be a single field or a JSON object with key value pairs.",
+					},
+					"value": {
+						"type": "string",
+						"description": "The value to set for the field. This is required if fieldname is a string.",
+					},
+				},
+				"required": ["doctype", "document_id", "fieldname"],
 				"additionalProperties": False,
 			}
 		else:

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -16,10 +16,7 @@ class RavenAIFunction(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-
-		from raven.raven_ai.doctype.raven_ai_function_params.raven_ai_function_params import (
-			RavenAIFunctionParams,
-		)
+		from raven.raven_ai.doctype.raven_ai_function_params.raven_ai_function_params import RavenAIFunctionParams
 
 		description: DF.SmallText
 		function_definition: DF.JSON | None
@@ -31,24 +28,7 @@ class RavenAIFunction(Document):
 		reference_doctype: DF.Link | None
 		requires_write_permissions: DF.Check
 		strict: DF.Check
-		type: DF.Literal[
-			"Get Document",
-			"Get Multiple Documents",
-			"Get List",
-			"Create Document",
-			"Create Multiple Documents",
-			"Update Document",
-			"Update Multiple Documents",
-			"Delete Document",
-			"Delete Multiple Documents",
-			"Submit Document",
-			"Cancel Document",
-			"Get Amended Document",
-			"Custom Function",
-			"Send Message",
-			"Attach File to Document",
-			"Get Report Result",
-		]
+		type: DF.Literal["Get Document", "Get Multiple Documents", "Get List", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document", "Custom Function", "Send Message", "Attach File to Document", "Get Report Result", "Get Value"]
 	# end: auto-generated types
 
 	def before_validate(self):
@@ -273,6 +253,29 @@ class RavenAIFunction(Document):
 					},
 				},
 				"required": ["filters", "fields"],
+				"additionalProperties": False,
+			}
+		elif self.type == "Get Value":
+			params = {
+				"type": "object",
+				"properties": {
+					"doctype": {
+						"type": "string",
+						"description": "The DocType to get the value from",
+					},
+					"filters": {
+						"type": "object",
+						"description": "Filters to apply when retrieving the value",
+					},
+					"fieldname": {
+						"anyOf": [
+							{"type": "string"},
+							{"type": "array", "items": {"type": "string"}}
+						],
+						"description": "The fields whose value needs to be returned. Can be a single field or a list of fields. If a list of fields is provided, the values will be returned as a tuple.",
+					},
+				},
+				"required": ["doctype", "filters", "fieldname"],
 				"additionalProperties": False,
 			}
 		else:

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -16,7 +16,10 @@ class RavenAIFunction(Document):
 
 	if TYPE_CHECKING:
 		from frappe.types import DF
-		from raven.raven_ai.doctype.raven_ai_function_params.raven_ai_function_params import RavenAIFunctionParams
+
+		from raven.raven_ai.doctype.raven_ai_function_params.raven_ai_function_params import (
+			RavenAIFunctionParams,
+		)
 
 		description: DF.SmallText
 		function_definition: DF.JSON | None
@@ -28,7 +31,26 @@ class RavenAIFunction(Document):
 		reference_doctype: DF.Link | None
 		requires_write_permissions: DF.Check
 		strict: DF.Check
-		type: DF.Literal["Get Document", "Get Multiple Documents", "Get List", "Create Document", "Create Multiple Documents", "Update Document", "Update Multiple Documents", "Delete Document", "Delete Multiple Documents", "Submit Document", "Cancel Document", "Get Amended Document", "Custom Function", "Send Message", "Attach File to Document", "Get Report Result", "Get Value", "Set Value"]
+		type: DF.Literal[
+			"Get Document",
+			"Get Multiple Documents",
+			"Get List",
+			"Create Document",
+			"Create Multiple Documents",
+			"Update Document",
+			"Update Multiple Documents",
+			"Delete Document",
+			"Delete Multiple Documents",
+			"Submit Document",
+			"Cancel Document",
+			"Get Amended Document",
+			"Custom Function",
+			"Send Message",
+			"Attach File to Document",
+			"Get Report Result",
+			"Get Value",
+			"Set Value",
+		]
 	# end: auto-generated types
 
 	def before_validate(self):
@@ -268,10 +290,7 @@ class RavenAIFunction(Document):
 						"description": "Filters to apply when retrieving the value",
 					},
 					"fieldname": {
-						"anyOf": [
-							{"type": "string"},
-							{"type": "array", "items": {"type": "string"}}
-						],
+						"anyOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}],
 						"description": "The fields whose value needs to be returned. Can be a single field or a list of fields. If a list of fields is provided, the values will be returned as a tuple.",
 					},
 				},
@@ -291,10 +310,7 @@ class RavenAIFunction(Document):
 						"description": "The ID of the document to set the value for",
 					},
 					"fieldname": {
-						"anyOf": [
-							{"type": "string"},
-							{"type": "object", "additionalProperties": True}
-						],
+						"anyOf": [{"type": "string"}, {"type": "object", "additionalProperties": True}],
 						"description": "The fields whose value needs to be set. Can be a single field or a JSON object with key value pairs.",
 					},
 					"value": {

--- a/raven/raven_bot/doctype/raven_bot/raven_bot.py
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.py
@@ -134,8 +134,7 @@ class RavenBot(Document):
 				description=self.description or "",
 				tools=self.get_tools_for_assistant(),
 				tool_resources=self.get_tool_resources_for_assistant(),
-				# TODO: configure the parameters being sent depending on the model - temperature, top_p, reasoning_effort
-				# reasoning_effort=reasoning_effort if model.startswith("o") else None,
+				reasoning_effort=reasoning_effort if model.startswith("o") else None,
 				temperature=self.temperature or 1,
 				top_p=self.top_p or 1,
 			)
@@ -180,8 +179,7 @@ class RavenBot(Document):
 				tools=self.get_tools_for_assistant(),
 				tool_resources=self.get_tool_resources_for_assistant(),
 				model=model,
-				# TODO: configure the parameters being sent depending on the model - temperature, top_p, reasoning_effort
-				# reasoning_effort=reasoning_effort if model.startswith("o") else None,
+				reasoning_effort=reasoning_effort if model.startswith("o") else None,
 				temperature=self.temperature or 1,
 				top_p=self.top_p or 1,
 			)

--- a/raven/raven_bot/doctype/raven_bot/raven_bot.py
+++ b/raven/raven_bot/doctype/raven_bot/raven_bot.py
@@ -134,7 +134,8 @@ class RavenBot(Document):
 				description=self.description or "",
 				tools=self.get_tools_for_assistant(),
 				tool_resources=self.get_tool_resources_for_assistant(),
-				reasoning_effort=reasoning_effort if model.startswith("o") else None,
+				# TODO: configure the parameters being sent depending on the model - temperature, top_p, reasoning_effort
+				# reasoning_effort=reasoning_effort if model.startswith("o") else None,
 				temperature=self.temperature or 1,
 				top_p=self.top_p or 1,
 			)
@@ -179,7 +180,8 @@ class RavenBot(Document):
 				tools=self.get_tools_for_assistant(),
 				tool_resources=self.get_tool_resources_for_assistant(),
 				model=model,
-				reasoning_effort=reasoning_effort if model.startswith("o") else None,
+				# TODO: configure the parameters being sent depending on the model - temperature, top_p, reasoning_effort
+				# reasoning_effort=reasoning_effort if model.startswith("o") else None,
 				temperature=self.temperature or 1,
 				top_p=self.top_p or 1,
 			)


### PR DESCRIPTION
# feat(ai): add new standard functions get_value and set_value

This PR introduces two new standard AI functions to enhance the Raven AI function calling:

## What's Added

- **Get Value**: Allows AI bots to retrieve values from the system - behaviour similar to frappe's get_value func
- **Set Value**: Allows AI bots to store/update values in the system - behaviour similar to frappe's set_value func

## Changes

- Added "Get Value" standard function to AI functions
- Added "Set Value" standard function to AI functions