### PR TITLE
feat: add get report result raven ai function

### DIFF
--- a/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
@@ -99,11 +99,12 @@ export const FUNCTION_TYPES = [
         requires_write_permissions: true,
         type: "Other"
     },
-    // {
-    //     value: "Get Report Result",
-    //     description: "Allows the bot to get the result of any report in the system.",
-    //     requires_write_permissions: true
-    // },
+    {
+        value: "Get Report Result",
+        description: "Allows the bot to get the result of any report in the system.",
+        requires_write_permissions: false,
+        type: "Other"
+    },
 ]
 
 export type VariableType = StringVariableType | NumberVariableType | BooleanVariableType | ObjectVariableType | ArrayVariableType

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -251,3 +251,33 @@ def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str 
 		return client.set_value(doctype, document_id, fieldname)
 	else:
 		return client.set_value(doctype, document_id, fieldname, value)
+
+
+def get_report_result(
+	report_name: str,
+	filters: dict = None,
+	limit=None,
+	user: str = None,
+	ignore_prepared_report: bool = False,
+	are_default_filters: bool = True,
+):
+	"""
+	Run a report and return the columns and result
+	"""
+	# fetch the particular report
+	report = frappe.get_doc("Report", report_name)
+	if not report:
+		return {
+			"message": f"Report {report_name} is not present in the system. Please create the report first."
+		}
+
+	# run the report by using the get_data method and return the columns and result
+	columns, data = report.get_data(
+		filters=filters,
+		limit=limit,
+		user=user,
+		ignore_prepared_report=ignore_prepared_report,
+		are_default_filters=are_default_filters,
+	)
+
+	return {"columns": columns, "data": data}

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -17,6 +17,7 @@ from raven.ai.functions import (
 	get_document,
 	get_documents,
 	get_list,
+	get_report_result,
 	get_value,
 	set_value,
 	submit_document,
@@ -300,6 +301,16 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							document_id=args.get("document_id"),
 							fieldname=args.get("fieldname"),
 							value=args.get("value"),
+						)
+
+					if function.type == "Get Report Result":
+						self.publish_event(f"Running report {args.get('report_name')}...")
+						function_output = get_report_result(
+							report_name=args.get("report_name"),
+							filters=args.get("filters"),
+							user=args.get("user", frappe.session.user),
+							ignore_prepared_report=args.get("ignore_prepared_report", False),
+							are_default_filters=args.get("are_default_filters", True),
 						)
 					tool_outputs.append(
 						{"tool_call_id": tool.id, "output": json.dumps(function_output, default=str)}

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -63,6 +63,7 @@ class RavenAIFunction(Document):
 			"Delete Multiple Documents",
 			"Send Message",
 			"Attach File to Document",
+			"Set Value",
 		]
 		if self.type in WRITE_PERMISSIONS:
 			self.requires_write_permissions = 1
@@ -72,6 +73,7 @@ class RavenAIFunction(Document):
 			"Get Multiple Documents",
 			"Get Report Result",
 			"Get List",
+			"Get Value",
 			"Get Amended Document",
 		]
 		if self.type in READ_PERMISSIONS:

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -323,6 +323,33 @@ class RavenAIFunction(Document):
 				"required": ["doctype", "document_id", "fieldname"],
 				"additionalProperties": False,
 			}
+		elif self.type == "Get Report Result":
+			params = {
+				"type": "object",
+				"properties": {
+					"report_name": {"type": "string", "description": "Report Name"},
+					"filters": {
+						"type": "object",
+						"properties": {
+							"company": {"type": "string", "description": "Company name to run the report for"},
+							"from_date": {"type": "string", "description": "generate report from this date"},
+							"to_date": {"type": "string", "description": "generate report till this date"},
+						},
+						"required": ["company", "to_date", "from_date"],
+					},
+					"limit": {"type": "number", "description": "Limit for the number of records to be fetched"},
+					"ignore_prepared_report": {
+						"type": "boolean",
+						"description": "Whether to ignore the prepared report",
+					},
+					"user": {"type": "string", "description": "The user to run the report for"},
+					"are_default_filters": {
+						"type": "boolean",
+						"description": "Whether to use the default filters",
+					},
+				},
+				"required": ["report_name"],
+			}
 		else:
 			params = self.build_params_json_from_table()
 


### PR DESCRIPTION
### Add Get Report Result AI Function

Implements a new AI function that allows bots to retrieve report data from the system.

#### Changes:
Added `get_report_result()` function in `raven/ai/functions.py` to execute reports and return columns/data
Updated AI handler to support the new function type
Added function schema definition with parameters for report name, filters, limits, and user context
Enabled "Get Report Result" in frontend function constants (read-only permissions)

#### Purpose:
This function would enables AI agents to act as intelligent report analysts that can:
- Retrieve and analyze data from existing system reports
- Provide insights and interpretations of report findings
- Answer questions about financial performance, trends, and anomalies
- Generate natural language summaries of complex report data

#### Value:
This function serves as the data extraction layer for future chart generation:
AI retrieves report data → analyzes patterns → requests visualizations
Future integration with platforms like Frappe Insights for automated chart creation

Video:

https://github.com/user-attachments/assets/3c8897ff-f5b7-4178-b574-a6410c27d47c



