### PR TITLE
feat(ai): add send message raven ai function

### DIFF
--- a/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
@@ -88,11 +88,12 @@ export const FUNCTION_TYPES = [
         description: "Custom function to be used in the system.",
         type: "Other"
     },
-    // { 
-    //     value: "Send Message",
-    //     description: "Function allows the bot to send a message to any user or channel in the system.",
-    //     requires_write_permissions: true
-    // },
+    {
+        value: "Send Message",
+        description: "Function allows the bot to send a message to any user or channel in the system.",
+        requires_write_permissions: true,
+        type: "Other"
+    },
     {
         value: "Attach File to Document",
         description: "Attach a file to any document.",

--- a/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
+++ b/frontend/src/components/feature/settings/ai/functions/FunctionConstants.ts
@@ -99,11 +99,12 @@ export const FUNCTION_TYPES = [
         requires_write_permissions: true,
         type: "Other"
     },
-    // {
-    //     value: "Get Report Result",
-    //     description: "Allows the bot to get the result of any report in the system.",
-    //     requires_write_permissions: true
-    // },
+    {
+        value: "Get Report Result",
+        description: "Allows the bot to get the result of any report in the system.",
+        requires_write_permissions: false,
+        type: "Other"
+    },
 ]
 
 export type VariableType = StringVariableType | NumberVariableType | BooleanVariableType | ObjectVariableType | ArrayVariableType

--- a/raven/ai/ai.py
+++ b/raven/ai/ai.py
@@ -185,7 +185,12 @@ def handle_bot_dm_with_assistants(message, bot):
 	# Send event to automatically open the thread
 	publish_ai_thread_created_event(message, message.channel_id)
 
-	stream_response(ai_thread_id=ai_thread.id, bot=bot, channel_id=thread_channel.name)
+	stream_response(
+		ai_thread_id=ai_thread.id,
+		bot=bot,
+		channel_id=thread_channel.name,
+		current_message_id=message.name,
+	)
 
 
 def handle_ai_thread_message(message, channel):
@@ -303,7 +308,12 @@ def handle_ai_thread_message_with_assistants(message, channel, bot):
 		docname=channel.name,
 	)
 
-	stream_response(ai_thread_id=channel.openai_thread_id, bot=bot, channel_id=channel.name)
+	stream_response(
+		ai_thread_id=channel.openai_thread_id,
+		bot=bot,
+		channel_id=channel.name,
+		current_message_id=message.name,
+	)
 
 
 def process_message_with_agent(

--- a/raven/ai/functions.py
+++ b/raven/ai/functions.py
@@ -251,3 +251,33 @@ def set_value(doctype: str, document_id: str, fieldname: str | dict, value: str 
 		return client.set_value(doctype, document_id, fieldname)
 	else:
 		return client.set_value(doctype, document_id, fieldname, value)
+
+
+def get_report_result(
+	report_name: str,
+	filters: dict = None,
+	limit=None,
+	user: str = None,
+	ignore_prepared_report: bool = False,
+	are_default_filters: bool = True,
+):
+	"""
+	Run a report and return the columns and result
+	"""
+	# fetch the particular report
+	report = frappe.get_doc("Report", report_name)
+	if not report:
+		return {
+			"message": f"Report {report_name} is not present in the system. Please create the report first."
+		}
+
+	# run the report by using the get_data method and return the columns and result
+	columns, data = report.get_data(
+		filters=filters,
+		limit=limit,
+		user=user,
+		ignore_prepared_report=ignore_prepared_report,
+		are_default_filters=are_default_filters,
+	)
+
+	return {"columns": columns, "data": data}

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -19,6 +19,7 @@ from raven.ai.functions import (
 	get_list,
 	get_report_result,
 	get_value,
+	send_message,
 	set_value,
 	submit_document,
 	update_document,
@@ -27,7 +28,7 @@ from raven.ai.functions import (
 from raven.ai.openai_client import get_open_ai_client
 
 
-def stream_response(ai_thread_id: str, bot, channel_id: str):
+def stream_response(ai_thread_id: str, bot, channel_id: str, current_message_id: str):
 
 	client = get_open_ai_client()
 
@@ -312,6 +313,17 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							ignore_prepared_report=args.get("ignore_prepared_report", False),
 							are_default_filters=args.get("are_default_filters", True),
 						)
+					if function.type == "Send Message":
+						self.publish_event("Delivering your message...")
+						function_output = send_message(
+							current_message_id,
+							text=args.get("content"),
+							bot=bot,
+							link_doctype=args.get("link_doctype"),
+							link_document=args.get("link_document"),
+							file=args.get("file"),
+						)
+
 					tool_outputs.append(
 						{"tool_call_id": tool.id, "output": json.dumps(function_output, default=str)}
 					)

--- a/raven/ai/handler.py
+++ b/raven/ai/handler.py
@@ -17,6 +17,7 @@ from raven.ai.functions import (
 	get_document,
 	get_documents,
 	get_list,
+	get_report_result,
 	get_value,
 	set_value,
 	submit_document,
@@ -300,6 +301,16 @@ def stream_response(ai_thread_id: str, bot, channel_id: str):
 							document_id=args.get("document_id"),
 							fieldname=args.get("fieldname"),
 							value=args.get("value"),
+						)
+
+					if function.type == "Get Report Result":
+						self.publish_event(f"Running report {args.get('report_name')}...")
+						function_output = get_report_result(
+							report_name=args.get("report_name"),
+							filters=args.get("filters"),
+							user=args.get("user", frappe.session.user),
+							ignore_prepared_report=args.get("ignore_prepared_report", False),
+							are_default_filters=args.get("are_default_filters", True),
 						)
 					tool_outputs.append(
 						{"tool_call_id": tool.id, "output": json.dumps(function_output, default=str)}

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -64,6 +64,7 @@ class RavenAIFunction(Document):
 			"Send Message",
 			"Attach File to Document",
 			"Set Value",
+			"Send Message",
 		]
 		if self.type in WRITE_PERMISSIONS:
 			self.requires_write_permissions = 1
@@ -349,6 +350,30 @@ class RavenAIFunction(Document):
 					},
 				},
 				"required": ["report_name"],
+			}
+		elif self.type == "Send Message":
+			params = {
+				"type": "object",
+				"properties": {
+					"content": {
+						"type": "string",
+						"description": "The text content of the message to send. Optional if file is provided.",
+					},
+					"link_doctype": {
+						"type": "string",
+						"description": "The doctype of the document to link the message to.",
+					},
+					"link_document": {
+						"type": "string",
+						"description": "The name of the document to link the message to.",
+					},
+					"file": {
+						"type": "string",
+						"description": "The file URL to send to the user. Will automatically determine if it's an image or file based on extension. Optional if content is provided.",
+					},
+				},
+				"required": [],
+				"additionalProperties": False,
 			}
 		else:
 			params = self.build_params_json_from_table()

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -63,6 +63,7 @@ class RavenAIFunction(Document):
 			"Delete Multiple Documents",
 			"Send Message",
 			"Attach File to Document",
+			"Set Value",
 		]
 		if self.type in WRITE_PERMISSIONS:
 			self.requires_write_permissions = 1
@@ -72,6 +73,7 @@ class RavenAIFunction(Document):
 			"Get Multiple Documents",
 			"Get Report Result",
 			"Get List",
+			"Get Value",
 			"Get Amended Document",
 		]
 		if self.type in READ_PERMISSIONS:

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -323,6 +323,33 @@ class RavenAIFunction(Document):
 				"required": ["doctype", "document_id", "fieldname"],
 				"additionalProperties": False,
 			}
+		elif self.type == "Get Report Result":
+			params = {
+				"type": "object",
+				"properties": {
+					"report_name": {"type": "string", "description": "Report Name"},
+					"filters": {
+						"type": "object",
+						"properties": {
+							"company": {"type": "string", "description": "Company name to run the report for"},
+							"from_date": {"type": "string", "description": "generate report from this date"},
+							"to_date": {"type": "string", "description": "generate report till this date"},
+						},
+						"required": ["company", "to_date", "from_date"],
+					},
+					"limit": {"type": "number", "description": "Limit for the number of records to be fetched"},
+					"ignore_prepared_report": {
+						"type": "boolean",
+						"description": "Whether to ignore the prepared report",
+					},
+					"user": {"type": "string", "description": "The user to run the report for"},
+					"are_default_filters": {
+						"type": "boolean",
+						"description": "Whether to use the default filters",
+					},
+				},
+				"required": ["report_name"],
+			}
 		else:
 			params = self.build_params_json_from_table()
 

--- a/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
+++ b/raven/raven_ai/doctype/raven_ai_function/raven_ai_function.py
@@ -357,7 +357,7 @@ class RavenAIFunction(Document):
 				"properties": {
 					"content": {
 						"type": "string",
-						"description": "The text content of the message to send. Optional if file is provided.",
+						"description": "The text content of the message to send. Either content or file must be provided.",
 					},
 					"link_doctype": {
 						"type": "string",
@@ -369,7 +369,7 @@ class RavenAIFunction(Document):
 					},
 					"file": {
 						"type": "string",
-						"description": "The file URL to send to the user. Will automatically determine if it's an image or file based on extension. Optional if content is provided.",
+						"description": "The file URL to send to the user. Will automatically determine if it's an image or file based on extension. Either content or file must be provided.",
 					},
 				},
 				"required": [],

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -126,6 +126,21 @@ class RavenMessage(Document):
 				)
 				unique_mentions.add(mention_id)
 
+	def extract_channel_mentions(self):
+		"""
+		Extract all channel mentions from the HTML content
+		"""
+		soup = BeautifulSoup(self.text, "html.parser")
+		channel_mentions = []
+		unique_channel_mentions = set()
+		for d in soup.find_all("span", attrs={"data-type": "channelMention"}):
+			channel_id = d.get("data-id")
+			if channel_id and channel_id not in unique_channel_mentions:
+				channel_mentions.append(channel_id)
+				unique_channel_mentions.add(channel_id)
+
+		return channel_mentions
+
 	def remove_empty_trailing_paragraphs(self, soup):
 		"""
 		Remove p, br tags that are at the end with no content


### PR DESCRIPTION
## Add "Send Message" AI Function for Agent Communication

### Overview
Introduces a new `Send Message` AI function that allows bots to send messages to users and channels mentioned in conversations.

### Key Features
- **Message Targeting**: Parses `@username` and `#channel` mentions from messages
- **Multi-format Support**: Handles text content, file attachments, and document links
- **Auto-channel Creation**: Creates DM channels for user mentions automatically
- **Validation**: Ensures either content or file is provided

### Technical Changes
- Added `send_message()` function with mention parsing logic
- Added `extract_channel_mentions()` method to `RavenMessage` class
- Added `current_message_id` parameter passing in AI handler to let the bot know the current message which would contain the mentions.

### Impact
- Enables proactive bot communication workflows. In future we can use this function to handover tasks between agents.
- Allows bots to notify relevant users about document updates, alerts, etc.
- Supports multi-modal messaging (text, files, document links)

### Video and Screenshots:

#### Expenso sends created expense claim to other user via mention(An example of us being able to send DocTypeLinks) - 
https://github.com/user-attachments/assets/bbc525f7-4946-469d-9485-97bbb4d4d4a7

#### Report Wizard sends insights and charts generated to user and channel mentions -
![CleanShot 2025-07-05 at 17 52 23@2x](https://github.com/user-attachments/assets/48fa2f0b-4420-4b57-9c8d-b3050b508790)

![CleanShot 2025-07-05 at 17 53 12@2x](https://github.com/user-attachments/assets/e5af73de-c6f8-4f3e-9b15-4c425d9d76fa)

![CleanShot 2025-07-05 at 17 55 47@2x](https://github.com/user-attachments/assets/9bbd70d0-65d5-479a-9a0d-f125ba8a522c)

![CleanShot 2025-07-05 at 17 56 25@2x](https://github.com/user-attachments/assets/c27c80f8-86f1-4ffb-be54-1f61343a04a9)

