### PR TITLE
feat: add mentioned users to thread

### DIFF
--- a/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
+++ b/raven/raven_channel_management/doctype/raven_channel_member/raven_channel_member.py
@@ -200,27 +200,26 @@ class RavenChannelMember(Document):
 		if not is_direct_message:
 
 			# Send a system message to the channel mentioning the member who joined
-			if not is_thread:
-				member_name = frappe.get_cached_value("Raven User", self.user_id, "full_name")
-				if self.user_id == frappe.session.user:
-					frappe.get_doc(
-						{
-							"doctype": "Raven Message",
-							"channel_id": self.channel_id,
-							"message_type": "System",
-							"text": f"{member_name} joined.",
-						}
-					).insert(ignore_permissions=True)
-				else:
-					current_user_name = frappe.get_cached_value("Raven User", frappe.session.user, "full_name")
-					frappe.get_doc(
-						{
-							"doctype": "Raven Message",
-							"channel_id": self.channel_id,
-							"message_type": "System",
-							"text": f"{current_user_name} added {member_name}.",
-						}
-					).insert(ignore_permissions=True)
+			member_name = frappe.get_cached_value("Raven User", self.user_id, "full_name")
+			if self.user_id == frappe.session.user:
+				frappe.get_doc(
+					{
+						"doctype": "Raven Message",
+						"channel_id": self.channel_id,
+						"message_type": "System",
+						"text": f"{member_name} joined.",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				current_user_name = frappe.get_cached_value("Raven User", frappe.session.user, "full_name")
+				frappe.get_doc(
+					{
+						"doctype": "Raven Message",
+						"channel_id": self.channel_id,
+						"message_type": "System",
+						"text": f"{current_user_name} added {member_name}.",
+					}
+				).insert(ignore_permissions=True)
 
 		self.invalidate_channel_members_cache()
 

--- a/raven/raven_messaging/doctype/raven_message/raven_message.py
+++ b/raven/raven_messaging/doctype/raven_message/raven_message.py
@@ -17,7 +17,12 @@ from raven.notification import (
 	send_notification_to_topic,
 	send_notification_to_user,
 )
-from raven.utils import get_raven_room, refresh_thread_reply_count, track_channel_visit
+from raven.utils import (
+	get_raven_room,
+	is_channel_member,
+	refresh_thread_reply_count,
+	track_channel_visit,
+)
 
 
 class RavenMessage(Document):
@@ -326,10 +331,11 @@ class RavenMessage(Document):
 				after_commit=True,
 			)
 		elif channel_doc.is_thread:
-			# TODO: Might be a good idea to just send this to the users who are participants in the thread - maybe not a lot of users?
-
 			# Get the number of replies in the thread
 			reply_count = refresh_thread_reply_count(self.channel_id)
+
+			self.add_mentioned_users_to_thread()
+
 			frappe.publish_realtime(
 				"thread_reply",
 				{
@@ -356,6 +362,26 @@ class RavenMessage(Document):
 				after_commit=True,
 				room=get_raven_room(),
 			)
+
+	def add_mentioned_users_to_thread(self):
+		"""
+		Add the mentioned users to the thread if they are members of the parent channel but not in the thread
+		"""
+		if not self.mentions:
+			return
+
+		parent_channel_id = frappe.get_cached_value("Raven Message", self.channel_id, "channel_id")
+		if parent_channel_id:
+			for mention in self.mentions:
+				if is_channel_member(parent_channel_id, mention.user) and not is_channel_member(
+					self.channel_id, mention.user
+				):
+					try:
+						frappe.get_doc(
+							{"doctype": "Raven Channel Member", "channel_id": self.channel_id, "user_id": mention.user}
+						).insert(ignore_permissions=True)
+					except Exception:
+						pass
 
 	def send_push_notification(self):
 		# Send Push Notification for the following:

--- a/raven/utils.py
+++ b/raven/utils.py
@@ -190,7 +190,9 @@ def get_thread_reply_count(thread_id: str) -> int:
 	return frappe.cache().hget(
 		"raven:thread_reply_count",
 		thread_id,
-		lambda: frappe.db.count("Raven Message", {"channel_id": thread_id}),
+		lambda: frappe.db.count(
+			"Raven Message", {"channel_id": thread_id, "message_type": ["!=", "System"]}
+		),
 	)
 
 
@@ -198,7 +200,9 @@ def refresh_thread_reply_count(thread_id: str):
 	"""
 	Refresh the thread reply count
 	"""
-	new_count = frappe.db.count("Raven Message", {"channel_id": thread_id})
+	new_count = frappe.db.count(
+		"Raven Message", {"channel_id": thread_id, "message_type": ["!=", "System"]}
+	)
 	frappe.cache().hset("raven:thread_reply_count", thread_id, new_count)
 
 	return new_count


### PR DESCRIPTION
1. Users are added to a thread when they are mentioned - provided that the users are also a part of the main channel
2. When creating a thread from a message with mentions, mentioned users are automatically added to the thread.

![image](https://github.com/user-attachments/assets/dca32aee-c886-43f6-8d12-6fc80341086e)
