### PR TITLE
feat: create a hook to trigger when reaction is deleted

### DIFF
--- a/raven/api/reactions.py
+++ b/raven/api/reactions.py
@@ -53,7 +53,11 @@ def react(message_id: str, reaction: str, is_custom: bool = False, emoji_name: s
 			"Raven Message Reaction",
 			filters={"message": message_id, "owner": user, "reaction_escaped": reaction_escaped},
 		)
-
+		
+		# Hook to trigger when delete reaction
+		for fn in frappe.get_hooks("raven_message_reaction_after_delete"):
+			frappe.get_attr(fn)(message_id)
+			
 		calculate_message_reaction(message_id, channel_id)
 		return "Ok"
 	except Exception as e:


### PR DESCRIPTION
Create a hook since the reaction is deleted directly in database, so don't trigger in on_trash doctype event.