### PR TITLE
chore(web): use atoms to track last visited workspace and channels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,9 +35,10 @@ const CACHE_KEYS = [
 
 const isDesktop = window.innerWidth > 768
 
-const lastWorkspace = localStorage.getItem('ravenLastWorkspace') ?? ''
-const lastChannel = localStorage.getItem('ravenLastChannel') ?? ''
+const lastWorkspace = JSON.parse(localStorage.getItem('ravenLastWorkspace') ?? '""') ?? ''
+const lastChannel = JSON.parse(localStorage.getItem('ravenLastChannel') ?? '""') ?? ''
 
+console.log("Last workspace", lastWorkspace)
 
 // Initialize emoji-mart
 init({

--- a/frontend/src/components/feature/channel-settings/delete-channel/DeleteChannelModal.tsx
+++ b/frontend/src/components/feature/channel-settings/delete-channel/DeleteChannelModal.tsx
@@ -7,6 +7,9 @@ import { AlertDialog, Button, Callout, Checkbox, Dialog, Flex, Text } from '@rad
 import { Loader } from '@/components/common/Loader'
 import { FiAlertTriangle } from 'react-icons/fi'
 import { toast } from 'sonner'
+import { useAtomValue } from 'jotai'
+import { lastChannelAtom, lastWorkspaceAtom } from '@/utils/lastVisitedAtoms'
+import { useResetAtom } from 'jotai/utils'
 
 type DeleteChannelModalProps = {
     onClose: () => void,
@@ -28,7 +31,8 @@ export const DeleteChannelModal = ({ onClose, onCloseParent, isDrawer, channelDa
 
     const navigate = useNavigate()
 
-    const lastWorkspace = localStorage.getItem('ravenLastWorkspace')
+    const lastWorkspace = useAtomValue(lastWorkspaceAtom)
+    const resetLastChannel = useResetAtom(lastChannelAtom)
 
     const onSubmit = () => {
         if (channelData?.name) {
@@ -38,7 +42,7 @@ export const DeleteChannelModal = ({ onClose, onCloseParent, isDrawer, channelDa
                     mutate(["channel_members", channelData.name], undefined, { revalidate: false })
                     onClose()
                     onCloseParent()
-                    localStorage.removeItem('ravenLastChannel')
+                    resetLastChannel()
                     if (lastWorkspace) {
                         navigate(`/${lastWorkspace}`)
                     } else {

--- a/frontend/src/components/feature/chat-header/ChannelHeader.tsx
+++ b/frontend/src/components/feature/chat-header/ChannelHeader.tsx
@@ -8,6 +8,8 @@ import { ViewChannelMemberAvatars } from "./ViewChannelMemberAvatars"
 import { BiChevronLeft } from "react-icons/bi"
 import { Link } from "react-router-dom"
 import { ViewPinnedMessagesButton } from "../pinned-messages/ViewPinnedMessagesButton"
+import { useAtomValue } from "jotai"
+import { lastWorkspaceAtom } from "@/utils/lastVisitedAtoms"
 
 interface ChannelHeaderProps {
     channelData: ChannelListItem
@@ -17,7 +19,7 @@ export const ChannelHeader = ({ channelData }: ChannelHeaderProps) => {
 
     // The channel header has the channel name, the channel type icon, edit channel name button, and the view or add members button
 
-    const lastWorkspace = localStorage.getItem('ravenLastWorkspace')
+    const lastWorkspace = useAtomValue(lastWorkspaceAtom)
 
     return (
         <PageHeader>

--- a/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
+++ b/frontend/src/components/feature/chat-header/DMChannelHeader.tsx
@@ -13,6 +13,8 @@ import useIsUserOnLeave from "@/hooks/fetchers/useIsUserOnLeave"
 import { UserContext } from "@/utils/auth/UserProvider"
 import { replaceCurrentUserFromDMChannelName } from "@/utils/operations"
 import { useIsDesktop } from "@/hooks/useMediaQuery"
+import { useAtomValue } from "jotai"
+import { lastWorkspaceAtom } from "@/utils/lastVisitedAtoms"
 
 interface DMChannelHeaderProps {
     channelData: DMChannelListItem,
@@ -52,7 +54,7 @@ export const DMChannelHeader = ({ channelData }: DMChannelHeaderProps) => {
 
     const isDesktop = useIsDesktop()
 
-    const lastWorkspace = localStorage.getItem('ravenLastWorkspace')
+    const lastWorkspace = useAtomValue(lastWorkspaceAtom)
 
     return (
         <PageHeader>

--- a/frontend/src/components/feature/workspaces/WorkspaceActionMenu.tsx
+++ b/frontend/src/components/feature/workspaces/WorkspaceActionMenu.tsx
@@ -2,8 +2,10 @@ import { Label } from '@/components/common/Form'
 import { Loader } from '@/components/common/Loader'
 import { ErrorBanner } from '@/components/layout/AlertBanner/ErrorBanner'
 import { HStack, Stack } from '@/components/layout/Stack'
+import { lastWorkspaceAtom } from '@/utils/lastVisitedAtoms'
 import { AlertDialog, Box, Button, Dialog, DropdownMenu, IconButton, TextField, VisuallyHidden } from '@radix-ui/themes'
 import { useFrappeDeleteDoc, useFrappePostCall, useSWRConfig } from 'frappe-react-sdk'
+import { useAtom } from 'jotai'
 import { useState } from 'react'
 import { AiOutlineEdit } from 'react-icons/ai'
 import { BiDotsVerticalRounded, BiTrash } from 'react-icons/bi'
@@ -65,6 +67,8 @@ const RenameWorkspaceDialog = ({ onOpenChange, workspaceID, workspaceName }: { o
 
     const { call, loading, error } = useFrappePostCall("frappe.model.rename_doc.update_document_title")
 
+    const [lastWorkspace, setLastWorkspace] = useAtom(lastWorkspaceAtom)
+
     const handleSubmit = () => {
         call({
             doctype: "Raven Workspace",
@@ -76,6 +80,10 @@ const RenameWorkspaceDialog = ({ onOpenChange, workspaceID, workspaceName }: { o
                 toast.success("Workspace renamed")
                 globalMutate("workspaces_list")
                 onOpenChange(false)
+                // Update local storage if the last used workspace was renamed
+                if (lastWorkspace === workspaceID) {
+                    setLastWorkspace(res.message)
+                }
                 navigate("../" + res.message, {
                     replace: true
                 })

--- a/frontend/src/components/layout/Sidebar/WorkspacesSidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/WorkspacesSidebar.tsx
@@ -10,6 +10,9 @@ import useUnreadMessageCount from '@/hooks/useUnreadMessageCount'
 import { ChannelListContext, ChannelListContextType } from '@/utils/channel/ChannelListProvider'
 import { generateAvatarColor } from '@/components/feature/selectDropdowns/GenerateAvatarColor'
 import { getInitials } from '@/components/common/UserAvatar'
+import { useSetAtom } from 'jotai'
+import { lastChannelAtom, lastWorkspaceAtom } from '@/utils/lastVisitedAtoms'
+import { useResetAtom } from 'jotai/utils'
 
 const WorkspacesSidebar = () => {
 
@@ -74,9 +77,12 @@ const WorkspaceItem = ({ workspace }: { workspace: WorkspaceFields & { unread_co
 
     const path = isSelected ? location.pathname : `/${workspace.name}`
 
+    const setLastWorkspace = useSetAtom(lastWorkspaceAtom)
+    const resetLastChannel = useResetAtom(lastChannelAtom)
+
     const openWorkspace = () => {
-        localStorage.setItem('ravenLastWorkspace', workspace.name)
-        localStorage.removeItem('ravenLastChannel')
+        setLastWorkspace(workspace.name)
+        resetLastChannel()
     }
 
     return <HStack position='relative' align='center' className='group'>

--- a/frontend/src/components/layout/WorkspaceSwitcherGrid.tsx
+++ b/frontend/src/components/layout/WorkspaceSwitcherGrid.tsx
@@ -7,6 +7,9 @@ import { useFrappeGetCall, useFrappePostCall, useSWRConfig } from 'frappe-react-
 import { MdArrowOutward } from 'react-icons/md'
 import { toast } from 'sonner'
 import { getErrorMessage } from './AlertBanner/ErrorBanner'
+import { useSetAtom } from 'jotai'
+import { lastChannelAtom, lastWorkspaceAtom } from '@/utils/lastVisitedAtoms'
+import { useResetAtom } from 'jotai/utils'
 
 const WorkspaceSwitcherGrid = () => {
 
@@ -101,9 +104,12 @@ const getLogo = (workspace: WorkspaceFields) => {
 const MyWorkspaceItem = ({ workspace }: { workspace: WorkspaceFields }) => {
     const logo = getLogo(workspace)
 
+    const setLastWorkspace = useSetAtom(lastWorkspaceAtom)
+    const resetLastChannel = useResetAtom(lastChannelAtom)
+
     const openWorkspace = () => {
-        localStorage.setItem('ravenLastWorkspace', workspace.name)
-        localStorage.removeItem('ravenLastChannel')
+        setLastWorkspace(workspace.name)
+        resetLastChannel()
     }
 
     return <Card asChild className='shadow-sm hover:scale-105 transition-all duration-200'>

--- a/frontend/src/pages/ChatSpace.tsx
+++ b/frontend/src/pages/ChatSpace.tsx
@@ -9,6 +9,8 @@ import { Outlet, useParams, useSearchParams } from "react-router-dom"
 import { useSWRConfig } from "frappe-react-sdk"
 import { UnreadChannelCountItem, UnreadCountData } from "@/utils/channel/ChannelListProvider"
 import { useIsMobile } from "@/hooks/useMediaQuery"
+import { useSetAtom } from "jotai"
+import { lastChannelAtom } from "@/utils/lastVisitedAtoms"
 
 const ChatSpace = () => {
 
@@ -36,10 +38,12 @@ const ChatSpaceArea = ({ channelID }: { channelID: string }) => {
 
     const baseMessage = searchParams.get('message_id')
 
+    const setLastChannel = useSetAtom(lastChannelAtom)
+
     useEffect(() => {
 
         // setting last visited channel in local storage
-        localStorage.setItem("ravenLastChannel", channelID)
+        setLastChannel(channelID)
 
         const unread_count = cache.get('unread_channel_count')
 

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -1,6 +1,8 @@
 import { HStack, Stack } from '@/components/layout/Stack'
 import { useIsMobile } from '@/hooks/useMediaQuery';
+import { lastChannelAtom, lastWorkspaceAtom } from '@/utils/lastVisitedAtoms';
 import { Button, Code, Flex, Heading, Link, Text } from '@radix-ui/themes'
+import { useAtomValue } from 'jotai';
 import { useNavigate, useRouteError } from 'react-router-dom'
 
 const ErrorPage = () => {
@@ -19,16 +21,17 @@ const ErrorPage = () => {
 
     const isMobile = useIsMobile()
 
+    const lastWorkspace = useAtomValue(lastWorkspaceAtom)
+    const lastChannel = useAtomValue(lastChannelAtom)
+
     const goToChannels = () => {
 
         if (isMobile) {
             navigate('/')
         } else {
-            const lastWorkspace = localStorage.getItem('ravenLastWorkspace')
-            const ravenLastChannel = localStorage.getItem('ravenLastChannel')
 
-            if (lastWorkspace && ravenLastChannel) {
-                navigate(`/${lastWorkspace}/${ravenLastChannel}`)
+            if (lastWorkspace && lastChannel) {
+                navigate(`/${lastWorkspace}/${lastChannel}`)
             } else if (lastWorkspace) {
                 navigate(`/${lastWorkspace}`)
             } else {

--- a/frontend/src/pages/settings/AI/ViewBot.tsx
+++ b/frontend/src/pages/settings/AI/ViewBot.tsx
@@ -8,9 +8,11 @@ import SettingsContentContainer from "@/components/layout/Settings/SettingsConte
 import SettingsPageHeader from "@/components/layout/Settings/SettingsPageHeader"
 import { HStack } from "@/components/layout/Stack"
 import { RavenBot } from "@/types/RavenBot/RavenBot"
+import { lastWorkspaceAtom } from "@/utils/lastVisitedAtoms"
 import { isEmpty } from "@/utils/validations"
 import { Button } from "@radix-ui/themes"
 import { useFrappeGetDoc, useFrappeUpdateDoc, SWRResponse, FrappeContext, FrappeConfig } from "frappe-react-sdk"
+import { useAtomValue } from "jotai"
 import { useContext, useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { FiExternalLink } from "react-icons/fi"
@@ -102,7 +104,7 @@ const OpenChatButton = ({ bot }: { bot: RavenBot }) => {
 
     const navigate = useNavigate()
 
-    const currentWorkspace = localStorage.getItem('ravenLastWorkspace')
+    const currentWorkspace = useAtomValue(lastWorkspaceAtom)
 
     const openChat = () => {
         call.post("raven.api.raven_channel.create_direct_message_channel", {

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,9 +1,11 @@
 import { SettingsSidebar } from '@/components/feature/userSettings/SettingsSidebar'
 import { useIsDesktop } from '@/hooks/useMediaQuery'
 import { ChannelListProvider } from '@/utils/channel/ChannelListProvider'
+import { lastChannelAtom, lastWorkspaceAtom } from '@/utils/lastVisitedAtoms'
 import { __ } from '@/utils/translations'
 import { UserListProvider } from '@/utils/users/UserListProvider'
 import { Box, Flex, Heading } from '@radix-ui/themes'
+import { useAtomValue } from 'jotai'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Link } from 'react-router-dom'
 import { Outlet } from "react-router-dom"
@@ -11,8 +13,8 @@ import { Outlet } from "react-router-dom"
 const Settings = () => {
     const isDesktop = useIsDesktop()
 
-    const lastWorkspace = localStorage.getItem('ravenLastWorkspace')
-    const lastChannel = localStorage.getItem('ravenLastChannel')
+    const lastWorkspace = useAtomValue(lastWorkspaceAtom)
+    const lastChannel = useAtomValue(lastChannelAtom)
 
     let path = '../'
 

--- a/frontend/src/utils/auth/UserProvider.tsx
+++ b/frontend/src/utils/auth/UserProvider.tsx
@@ -1,8 +1,10 @@
 import { getErrorMessage } from '@/components/layout/AlertBanner/ErrorBanner'
 import { useFrappeAuth, useSWRConfig } from 'frappe-react-sdk'
+import { useResetAtom } from 'jotai/utils'
 import { FC, PropsWithChildren } from 'react'
 import { createContext } from 'react'
 import { toast } from 'sonner'
+import { lastChannelAtom, lastWorkspaceAtom } from '../lastVisitedAtoms'
 
 interface UserContextProps {
     isLoading: boolean,
@@ -23,9 +25,12 @@ export const UserProvider: FC<PropsWithChildren> = ({ children }) => {
     const { mutate } = useSWRConfig()
     const { logout, currentUser, updateCurrentUser, isLoading } = useFrappeAuth()
 
+    const resetLastWorkspace = useResetAtom(lastWorkspaceAtom)
+    const resetLastChannel = useResetAtom(lastChannelAtom)
+
     const handleLogout = async () => {
-        localStorage.removeItem('ravenLastChannel')
-        localStorage.removeItem('ravenLastWorkspace')
+        resetLastChannel()
+        resetLastWorkspace()
         localStorage.removeItem('app-cache')
 
         // Disable push notifications

--- a/frontend/src/utils/lastVisitedAtoms.ts
+++ b/frontend/src/utils/lastVisitedAtoms.ts
@@ -1,0 +1,8 @@
+import { atomWithStorage } from "jotai/utils";
+
+export const lastWorkspaceAtom = atomWithStorage<string>('ravenLastWorkspace', '', undefined, {
+    getOnInit: true
+})
+export const lastChannelAtom = atomWithStorage<string>('ravenLastChannel', '', undefined, {
+    getOnInit: true
+})


### PR DESCRIPTION
Also fixed an issue where if you rename a workspace and then go back to the chat space, it was using the older workspace ID forcing the user to select the workspace again.