### PR TITLE
fix(polls): lock poll document when updating votes

### DIFF
--- a/raven/raven_messaging/doctype/raven_poll_vote/raven_poll_vote.py
+++ b/raven/raven_messaging/doctype/raven_poll_vote/raven_poll_vote.py
@@ -63,7 +63,7 @@ def update_poll_votes(poll_id):
 	"""
 	To update all the votes in a poll, instead of updating the document directly, just write to the child table to avoid setting the "modified" timestamp.
 	"""
-	poll = frappe.get_cached_doc("Raven Poll", poll_id)
+	poll = frappe.get_cached_doc("Raven Poll", poll_id, for_update=True)
 	# get votes for each option
 	poll_votes = frappe.get_all(
 		"Raven Poll Vote",


### PR DESCRIPTION
@ankush This should be good enough to fix the concurrent requests right? Even though the document is not being "saved", a lock on the document should be released as soon as the transaction is committed?

Fixes #1777 