### PR TITLE
feat(v3): optimistic file uploads

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -24,6 +24,16 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_",
+          "destructuredArrayIgnorePattern": "^_",
+          "ignoreRestSiblings": true
+        }
+      ]
     },
   },
 )

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-hover-card": "^1.1.7",
     "@radix-ui/react-label": "^2.1.3",
     "@radix-ui/react-popover": "^1.1.14",
+    "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-radio-group": "^1.2.4",
     "@radix-ui/react-scroll-area": "^1.2.4",
     "@radix-ui/react-select": "^2.1.7",

--- a/apps/web/src/components/features/ChatInput/ChatInput.tsx
+++ b/apps/web/src/components/features/ChatInput/ChatInput.tsx
@@ -1,0 +1,25 @@
+import { Input } from "@components/ui/input"
+import { InputFileList, AddFileButton } from "./InputFiles"
+import SendButton from "./SendButton"
+
+interface ChatInputProps {
+    channelID: string
+}
+const ChatInput = ({ channelID }: ChatInputProps) => {
+    return (
+        <div className="p-2 pb-4 w-full flex flex-col gap-2">
+            <InputFileList channelID={channelID} />
+            <div className="flex gap-2 items-end rounded-sm w-full">
+                <div className="flex items-center justify-center">
+                    <AddFileButton channelID={channelID} />
+                </div>
+                <div className="w-full">
+                    <Input type="text" placeholder="Type a message..." className="w-full" autoFocus />
+                </div>
+                <SendButton channelID={channelID} />
+            </div>
+        </div>
+    )
+}
+
+export default ChatInput

--- a/apps/web/src/components/features/ChatInput/InputFiles.tsx
+++ b/apps/web/src/components/features/ChatInput/InputFiles.tsx
@@ -1,0 +1,135 @@
+import { useAtomValue } from 'jotai'
+import { uploadingFilesAtom, uploadedFilesAtom, useAttachFile, useRemoveFile } from './useFileInput'
+import { Button } from '@components/ui/button'
+import { AlertCircleIcon, PlusIcon, Trash2Icon } from 'lucide-react'
+import { useMemo, useRef } from 'react'
+import FileTypeIcon from '@components/common/FileIcons/FileTypeIcon'
+import { formatBytes, getFileExtension } from '@raven/lib/utils/operations'
+import { ProgressCircle } from '@components/ui/circular-progress'
+
+type InputFilesProps = {
+    channelID: string
+}
+
+export const InputFileList = ({ channelID }: InputFilesProps) => {
+
+    const uploadingFiles = useAtomValue(uploadingFilesAtom(channelID))
+    const uploadedFiles = useAtomValue(uploadedFilesAtom(channelID))
+
+    const files = useMemo(() => {
+
+        const f: FileItemType[] = [...uploadingFiles]
+
+        uploadedFiles.forEach(file => {
+            f.push({
+                ...file,
+                status: 'uploaded' as const
+            })
+        })
+
+        return f.sort((a, b) => a.timestamp - b.timestamp)
+
+    }, [uploadingFiles, uploadedFiles])
+
+    return (
+        <div className='flex gap-2 flex-wrap'>
+            {files.map((file) => (
+                <FileItem key={file.id} file={file} channelID={channelID} />
+            ))}
+        </div>
+    )
+}
+
+interface FileItemType {
+    id: string,
+    fileName: string,
+    size: number,
+    timestamp: number,
+    uploadProgress?: number,
+    status: 'uploading' | 'uploaded' | 'error',
+    fileID?: string,
+    fileURL?: string,
+}
+
+const FileItem = ({ file, channelID }: { file: FileItemType, channelID: string }) => {
+
+    const onRemoveFile = useRemoveFile(channelID)
+
+    const extension = getFileExtension(file.fileName)
+
+    const onRemoveClick = () => {
+        if (file.fileID) {
+            onRemoveFile(file.fileID)
+        }
+    }
+
+    return <div className="rounded-lg border border-gray-200 dark:border-gray-200 min-w-64">
+        <div className="flex items-center gap-2 p-2">
+            <div className="flex-shrink-0">
+                <FileTypeIcon fileType={extension} size="sm" />
+            </div>
+
+            <div className="flex-1 min-w-0">
+                <h4 className="text-xs font-medium text-gray-900 dark:text-gray-900 truncate">
+                    {file.fileName}
+                </h4>
+                <p className="text-xs text-gray-500 dark:text-gray-500">
+                    {formatBytes(file.size)}
+                </p>
+            </div>
+            {/* When the file is being uploaded, show a circular progress bar and when it's uploaded show the delete button */}
+            <div className="flex items-center size-9 justify-center">
+                {file.status === 'uploading' &&
+                    <div className='flex items-center justify-center size-9'>
+                        <ProgressCircle value={file.uploadProgress ?? 0} className='text-green-500' />
+                    </div>}
+                {file.status === 'uploaded' && (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onRemoveClick}
+                        title="Remove File"
+                    >
+                        <Trash2Icon />
+                    </Button>
+                )}
+                {file.status === 'error' && (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onRemoveClick}
+                        title="Remove File"
+                    >
+                        <AlertCircleIcon className='text-destructive' />
+                    </Button>
+                )}
+            </div>
+        </div>
+    </div>
+}
+
+/** Temp component */
+export const AddFileButton = ({ channelID }: { channelID: string }) => {
+
+    const fileInputRef = useRef<HTMLInputElement>(null)
+
+    const onAddFile = useAttachFile(channelID)
+
+    const onClick = () => {
+        fileInputRef.current?.click()
+    }
+
+    return <>
+        <input type="file" multiple
+            ref={fileInputRef}
+            onChange={(e) => {
+                const files = e.target.files
+                if (files) {
+                    onAddFile(files)
+                }
+            }} className='hidden' />
+        <Button variant="secondary" size="icon" onClick={onClick}>
+            <PlusIcon />
+        </Button>
+    </>
+}

--- a/apps/web/src/components/features/ChatInput/InputFiles.tsx
+++ b/apps/web/src/components/features/ChatInput/InputFiles.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai'
-import { uploadingFilesAtom, uploadedFilesAtom, useAttachFile, useRemoveFile } from './useFileInput'
+import { uploadingFilesAtom, uploadedFilesAtom, useAttachFile, useRemoveFile, FileItemType } from './useFileInput'
 import { Button } from '@components/ui/button'
 import { AlertCircleIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { useMemo, useRef } from 'react'
@@ -28,39 +28,25 @@ export const InputFileList = ({ channelID }: InputFilesProps) => {
         })
 
         return f.sort((a, b) => a.timestamp - b.timestamp)
-
     }, [uploadingFiles, uploadedFiles])
+
+    const onRemove = useRemoveFile(channelID)
 
     return (
         <div className='flex gap-2 flex-wrap'>
             {files.map((file) => (
-                <FileItem key={file.id} file={file} channelID={channelID} />
+                <FileItem key={file.id} file={file} onRemove={onRemove} />
             ))}
         </div>
     )
 }
 
-interface FileItemType {
-    id: string,
-    fileName: string,
-    size: number,
-    timestamp: number,
-    uploadProgress?: number,
-    status: 'uploading' | 'uploaded' | 'error',
-    fileID?: string,
-    fileURL?: string,
-}
-
-const FileItem = ({ file, channelID }: { file: FileItemType, channelID: string }) => {
-
-    const onRemoveFile = useRemoveFile(channelID)
+const FileItem = ({ file, onRemove }: { file: FileItemType, onRemove: (file: FileItemType) => void }) => {
 
     const extension = getFileExtension(file.fileName)
 
     const onRemoveClick = () => {
-        if (file.fileID) {
-            onRemoveFile(file.fileID)
-        }
+        onRemove(file)
     }
 
     return <div className="rounded-lg border border-gray-200 dark:border-gray-200 min-w-64">

--- a/apps/web/src/components/features/ChatInput/SendButton.tsx
+++ b/apps/web/src/components/features/ChatInput/SendButton.tsx
@@ -1,0 +1,48 @@
+import { Button } from "@components/ui/button"
+import { useFrappeCreateDoc } from "frappe-react-sdk"
+import { useAtom } from "jotai"
+import { SendIcon } from "lucide-react"
+import { uploadedFilesAtom } from "./useFileInput"
+
+type SendButtonProps = {
+    channelID: string
+}
+
+const SendButton = ({ channelID }: SendButtonProps) => {
+
+    const { createDoc } = useFrappeCreateDoc()
+
+    const [files, setFiles] = useAtom(uploadedFilesAtom(channelID))
+
+    /** 
+     * 
+     * When the user clicks the send button, we need to upload the editor content as well as upload all the files.
+     * 
+     * There might be cases where the files have not yet uploaded to the server. In such cases, we should wait for the files to upload and then create the messages.
+     * 
+     */
+
+    const onClick = () => {
+
+        /** TODO: Check for uploading files and queue messages */
+
+        const promises = files.map(f => createDoc('Raven Message', {
+            channel_id: channelID,
+            message_type: "File",
+            file: f.fileURL
+        }))
+
+        Promise.all(promises).then(() => {
+            setFiles([])
+        })
+    }
+    return (
+        <div className="flex items-center justify-center">
+            <Button size="icon" onClick={onClick}>
+                <SendIcon />
+            </Button>
+        </div>
+    )
+}
+
+export default SendButton

--- a/apps/web/src/components/features/ChatInput/useFileInput.ts
+++ b/apps/web/src/components/features/ChatInput/useFileInput.ts
@@ -1,0 +1,141 @@
+import { atomFamily, atomWithStorage } from 'jotai/utils'
+import { atom, useSetAtom } from 'jotai'
+import { FrappeConfig, FrappeContext, useFrappeDeleteDoc } from 'frappe-react-sdk'
+import { useContext } from 'react'
+import { toast } from 'sonner'
+
+/**
+ * 
+ * For file uploads, we need to consider a few scenarios:
+ * 
+ * 1. User selects multiple files, but then hits the send button. Some files were uploaded, some were still inflight. 
+ * In such a case, we queue the message and when all files upload, we process the queue.
+ * 
+ * 2. User selects a file and it's being uploaded but the user then closes the tab - in this case we lose the file (acceptable)
+ * 3. User selects a file and it's being uploaded - the user can switch channels when the file is being uploaded and resume once back
+ * 4. User selects a file and it's uploaded - then the user refreshes the tab - the user should still see the file in the chat input.
+ * 
+ * To cater to the above:
+ * 
+ * 1. Maintain a local state for all files that are being uploaded (uploadingFilesAtom) (3)
+ * 2. Maintain a local state for all files that are uploaded (uploadedFilesAtom) - which is persisted in local storage (4)
+ * 3. When a file finishes uploading, update uploadedFilesAtom, and check if the file with it's ID is in any queued message (another atom) (1)
+ * 4. If the file is in a queued message, process the queued message (1)
+ * 
+ */
+
+export interface InputFileType {
+    /** The file object picked by the user */
+    file: File,
+    /** Upload progress */
+    uploadProgress?: number,
+    status: 'uploading' | 'error',
+    /** Frontend generated ID */
+    id: string,
+    /** Name of the file */
+    fileName: string,
+    /** Size of the file in bytes */
+    size: number,
+    /** When the file was uploaded in milliseconds */
+    timestamp: number
+}
+
+export interface UploadedFile {
+    /** File ID returned from the server */
+    fileID: string
+    /** File URL returned from the server */
+    fileURL: string,
+    /** Frontend generated ID */
+    id: string,
+    /** Name of the file */
+    fileName: string,
+    /** Size of the file in bytes */
+    size: number,
+    /** When the file was uploaded in milliseconds */
+    timestamp: number
+}
+
+/** Atom to track files that are being uploaded per channel */
+export const uploadingFilesAtom = atomFamily((_channelID: string) => atom<InputFileType[]>([]))
+
+/** Atom to track files that are uploaded per channel */
+export const uploadedFilesAtom = atomFamily((channelID: string) => atomWithStorage<UploadedFile[]>(`uploaded-files-${channelID}`, []))
+
+
+export const useAttachFile = (channelID: string) => {
+
+    const { file } = useContext(FrappeContext) as FrappeConfig
+
+
+    const setUploadingFiles = useSetAtom(uploadingFilesAtom(channelID))
+    const setUploadedFiles = useSetAtom(uploadedFilesAtom(channelID))
+
+    /** 
+     * When a file is attached by the user, start uploading it immediately
+     * The user should not wait for files to upload when they hit the send button.
+     */
+    const onAddFile = (files: FileList) => {
+        const filesToBeUploaded = Array.from(files).map((file) => ({
+            file: file,
+            uploadProgress: 0,
+            status: 'uploading' as const,
+            id: crypto.randomUUID(),
+            fileName: file.name,
+            size: file.size,
+            timestamp: Date.now()
+        }))
+        setUploadingFiles((prevFiles) => [...prevFiles, ...filesToBeUploaded])
+
+        for (const f of filesToBeUploaded) {
+            file.uploadFile(f.file, {
+                doctype: 'Raven Message',
+                isPrivate: true
+            }, (_uploadedBytes, _totalBytes, progress) => {
+                const progressPercentage = Math.round((progress?.progress ?? 0) * 100)
+                setUploadingFiles((prevFiles) => prevFiles.map((file) => file.id === f.id ? { ...file, uploadProgress: progressPercentage, status: 'uploading' as const } : file))
+            }).then(res => {
+                // When upload is finished, add the file to the uploaded files atom and remove from the uploading files atom
+                setUploadedFiles((prevFiles) => [...prevFiles, {
+                    fileID: res.data.message.name,
+                    fileURL: res.data.message.file_url,
+                    id: f.id,
+                    fileName: f.fileName,
+                    size: f.size,
+                    timestamp: f.timestamp
+                }])
+                setUploadingFiles((prevFiles) => prevFiles.filter((file) => file.id !== f.id))
+
+                // TODO: Check if this file is a part of any queued message. If yes, we need to process the message
+            }).catch(() => {
+                toast.error("There was an error while uploading the file " + f.file.name)
+                setUploadingFiles((prevFiles) => prevFiles.map((file) => file.id === f.id ? { ...file, status: 'error' as const } : file))
+            })
+        }
+    }
+
+    return onAddFile
+}
+
+export const useRemoveFile = (channelID: string) => {
+
+    const { deleteDoc } = useFrappeDeleteDoc()
+    const setFiles = useSetAtom(uploadedFilesAtom(channelID))
+
+    /** 
+     * TODO: Add support for AbortController to cancel requests mid-flight
+     * When the user decides to delete a file they attached, check if the file is being uploaded.
+     * If it is already uploaded, delete the file from the server.
+     * If it is being uploaded, wait for the file to upload and then delete the file from the server.
+     * 
+     * File ID is the server file ID
+     */
+    const onRemoveFile = (serverFileID: string) => {
+        setFiles((prevFiles) => prevFiles.filter((f) => f.fileID !== serverFileID))
+
+        if (serverFileID) {
+            deleteDoc('File', serverFileID)
+        }
+    }
+
+    return onRemoveFile
+}

--- a/apps/web/src/components/ui/circular-progress.tsx
+++ b/apps/web/src/components/ui/circular-progress.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@lib/utils'
+import type React from 'react'
+
+export interface ProgressCircleProps extends React.ComponentProps<'svg'> {
+    value: number
+    className?: string
+}
+
+// https://github.com/shadcn-ui/ui/issues/697
+// https://github.com/shadcn-ui/ui/issues/697#issuecomment-2621653578 CircularProgress
+
+function clamp(input: number, a: number, b: number): number {
+    return Math.max(Math.min(input, Math.max(a, b)), Math.min(a, b))
+}
+
+// match values with lucide icons for compatibility
+const size = 24
+const strokeWidth = 4
+
+// fix to percentage values
+const total = 100
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/progressbar_role
+ */
+export const ProgressCircle = ({ value, className, ...restSvgProps }: ProgressCircleProps) => {
+    const normalizedValue = clamp(value, 0, total)
+
+    const radius = (size - strokeWidth) / 2
+    const circumference = 2 * Math.PI * radius
+    const progress = (normalizedValue / total) * circumference
+    const halfSize = size / 2
+
+    const commonParams = {
+        cx: halfSize,
+        cy: halfSize,
+        r: radius,
+        fill: 'none',
+        strokeWidth,
+    }
+
+    return (
+        // biome-ignore lint/a11y/useFocusableInteractive: false positive (progress + progressbar are not focusable interactives)
+        // biome-ignore lint/nursery/useAriaPropsSupportedByRole: biome rule at odds with mdn docs (presumed nursary bug with rule)
+        <svg
+            // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: false positive (progressbar not an interactive role)
+            role="progressbar"
+            viewBox={`0 0 ${size} ${size}`}
+            className={cn('size-4 text-primary', className)}
+            aria-valuenow={normalizedValue}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            {...restSvgProps}
+        >
+            <circle {...commonParams} className="stroke-current/25" />
+            <circle
+                {...commonParams}
+                stroke="currentColor"
+                strokeDasharray={circumference}
+                strokeDashoffset={circumference - progress}
+                strokeLinecap="round"
+                transform={`rotate(-90 ${halfSize} ${halfSize})`}
+                className="stroke-current"
+            />
+        </svg>
+    )
+}

--- a/apps/web/src/components/ui/progress.tsx
+++ b/apps/web/src/components/ui/progress.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@lib/utils"
+
+function Progress({
+    className,
+    value,
+    ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+    return (
+        <ProgressPrimitive.Root
+            data-slot="progress"
+            className={cn(
+                "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+                className
+            )}
+            {...props}
+        >
+            <ProgressPrimitive.Indicator
+                data-slot="progress-indicator"
+                className="bg-primary h-full w-full flex-1 transition-all"
+                style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+            />
+        </ProgressPrimitive.Root>
+    )
+}
+
+export { Progress }

--- a/apps/web/src/pages/Channel.tsx
+++ b/apps/web/src/pages/Channel.tsx
@@ -3,6 +3,7 @@ import ChannelHeader from '../components/features/channel/ChannelHeader/ChannelH
 import ChannelSettingsDrawer from '../components/features/channel/ChannelSettingsDrawer/ChannelSettingsDrawer';
 import ChannelMembersDrawer from '../components/features/channel/ChannelMembersDrawer/ChannelMembersDrawer';
 import ChatStream from "../components/features/message/ChatStream";
+import ChatInput from '@components/features/ChatInput/ChatInput';
 
 export default function Channel() {
 
@@ -15,6 +16,8 @@ export default function Channel() {
 
     const isDrawerOpen = drawerType !== null
 
+    const channelID = "general"
+
     return (
         <div className="flex flex-col h-full">
             <ChannelHeader
@@ -25,6 +28,7 @@ export default function Channel() {
                 {/* Main Content */}
                 <div className={`transition-all duration-300 ${isDrawerOpen ? 'w-[calc(100%-340px)]' : 'w-full'} h-full flex flex-col`}>
                     <ChatStream />
+                    <ChatInput channelID={channelID} />
                 </div>
                 {/* Channel Drawer */}
                 {isDrawerOpen && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3346,7 +3346,7 @@
   dependencies:
     "@radix-ui/react-slot" "1.2.3"
 
-"@radix-ui/react-progress@1.1.7":
+"@radix-ui/react-progress@1.1.7", "@radix-ui/react-progress@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.7.tgz#a2b76398b3f24b6bd5e37f112b1e30fbedd4f38e"
   integrity sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==


### PR DESCRIPTION
Upload files as soon as the user adds them to the chatbox optimistically to avoid waiting. 

If file uploads fail, allow users to remove them. If user decides to cancel an upload, they can delete the file from the server.

TODO: when sending messages, queue up messages with files still not uploaded.

https://github.com/user-attachments/assets/952ce0e2-2688-403c-8ac8-70c725bcac93

