### PR TITLE
fix(polls): correct percentage calculation in View Votes dialog

### DIFF
--- a/raven/api/raven_poll.py
+++ b/raven/api/raven_poll.py
@@ -174,12 +174,15 @@ def get_all_votes(poll_id):
 			option = vote["option"]
 			results[option]["users"].append(vote["user_id"])
 
-		# Calculate total votes
-		total_votes = sum(result["count"] for result in results.values())
+		# Calculate total votes (use unique voters, not sum of all votes)
+		total_votes = poll_doc.total_votes or 0
 
 		# Calculate percentages
 		for result in results.values():
-			result["percentage"] = (result["count"] / total_votes) * 100
+			if total_votes > 0:
+				result["percentage"] = (result["count"] / total_votes) * 100
+			else:
+				result["percentage"] = 0
 
 		return results
 


### PR DESCRIPTION
**Summary**
  Fixes inconsistent poll percentage calculations between main poll display and View Votes dialog.

 **Problem**
  - Main poll showed: Option 1 = 100%, Option 2 = 50%
  - View Votes showed: Option 1 = 66.67%, Option 2 = 33.33%
  - Same poll data, different percentages → user confusion
  
**Main poll** 
<img width="522" height="265" alt="Screenshot 2025-10-29 at 4 09 10 PM" src="https://github.com/user-attachments/assets/5bb0e98f-ea03-4aa8-9907-c1718e34c5e2" />

**View Votes Dialog Before**

<img width="589" height="652" alt="Screenshot 2025-10-29 at 4 09 41 PM" src="https://github.com/user-attachments/assets/57041cc5-7e7b-422d-b96f-061894373f54" />

**View Votes Dialog After**

<img width="600" height="625" alt="Screenshot 2025-10-29 at 4 09 19 PM" src="https://github.com/user-attachments/assets/0603205a-c1a3-4ed1-a996-5f9fee23835c" />
