### PR TITLE
fix: sync full_name from User to Raven User on update

### DIFF
--- a/raven/raven/doctype/raven_user/raven_user.py
+++ b/raven/raven/doctype/raven_user/raven_user.py
@@ -123,14 +123,14 @@ def add_user_to_raven(doc, method):
 
 			if has_raven_role:
 				raven_user = frappe.get_doc("Raven User", {"user": doc.name})
-				if not doc.full_name:
-					raven_user.full_name = doc.first_name
+				raven_user.full_name = doc.full_name or doc.first_name
+				raven_user.first_name = doc.first_name
 				raven_user.enabled = doc.enabled
 				raven_user.save(ignore_permissions=True)
 			else:
 				raven_user = frappe.get_doc("Raven User", {"user": doc.name})
-				if not doc.full_name:
-					raven_user.full_name = doc.first_name
+				raven_user.full_name = doc.full_name or doc.first_name
+				raven_user.first_name = doc.first_name
 				raven_user.enabled = 0
 				raven_user.save(ignore_permissions=True)
 		else:
@@ -147,8 +147,8 @@ def add_user_to_raven(doc, method):
 					# Create a Raven User record for the user.
 					raven_user = frappe.new_doc("Raven User")
 					raven_user.user = doc.name
-					if not doc.full_name:
-						raven_user.full_name = doc.first_name
+					raven_user.full_name = doc.full_name or doc.first_name
+					raven_user.first_name = doc.first_name
 					raven_user.enabled = doc.enabled
 					raven_user.insert(ignore_permissions=True)
 


### PR DESCRIPTION
**Problem**
when a User's name is changed in ERPNext, the change doesn't sync to the Raven User record. This affects user display names throughout the Raven chat interface.

**soluton**
  Always sync names instead of checking condition:


