### PR TITLE
fix: Open chat in new tab for AI agents

### DIFF
--- a/frontend/src/pages/settings/AI/ViewBot.tsx
+++ b/frontend/src/pages/settings/AI/ViewBot.tsx
@@ -16,7 +16,7 @@ import { useAtomValue } from "jotai"
 import { useContext, useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { FiExternalLink } from "react-icons/fi"
-import { useNavigate, useParams } from "react-router-dom"
+import { useParams } from "react-router-dom"
 import { toast } from "sonner"
 
 type Props = {}
@@ -102,19 +102,27 @@ const OpenChatButton = ({ bot }: { bot: RavenBot }) => {
 
     const { call } = useContext(FrappeContext) as FrappeConfig
 
-    const navigate = useNavigate()
-
     const currentWorkspace = useAtomValue(lastWorkspaceAtom)
 
     const openChat = () => {
         call.post("raven.api.raven_channel.create_direct_message_channel", {
             user_id: bot.raven_user
         }).then((res) => {
-            if (currentWorkspace) {
-                navigate(`/${currentWorkspace}/${res.message}`)
-            } else {
-                navigate(`/channel/${res.message}`)
+            const chatPath = currentWorkspace
+                ? `/${currentWorkspace}/${res.message}`
+                : `/channel/${res.message}`
+
+            let basePath = `${import.meta.env.VITE_BASE_NAME}`
+            if (!window.location.origin.endsWith("/")) {
+                basePath = "/" + basePath
             }
+
+            const fullUrl = `${window.location.origin}${basePath}${chatPath}`
+
+            window.open(fullUrl, '_blank')
+        }).catch((error) => {
+            toast.error('Failed to create chat channel')
+            console.error(error)
         })
     }
 


### PR DESCRIPTION
 **Fixes**: "Open Chat" button to open in new tab instead of same window.

  **Changes:**
  - Replace navigate() with window.open()
  - Use VITE_BASE_NAME for URL construction
  - Add error handling for failed API calls

  **Why:**
  Button has **external link icon** but was opening in same window.
