### PR TITLE
fix: add scope to manifest in Vite configuration

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig(({ command, mode }) => {
 			manifest: {
 				name: "Raven",
 				start_url: `/${env.VITE_BASE_NAME}`,
+				scope: `/${env.VITE_BASE_NAME}/`,
 				short_name: "Raven",
 				description: "Simple, work messaging tool.",
 				display: "standalone",


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/scope

Before: scope was auto-set to `/assets/raven/raven/`
After: scope is correctly set to `/raven/`