### PR TITLE
fix(ErrorBanner): check _error_message for permission error messages

### DIFF
--- a/frontend/src/components/layout/AlertBanner/ErrorBanner.tsx
+++ b/frontend/src/components/layout/AlertBanner/ErrorBanner.tsx
@@ -32,7 +32,15 @@ const getErrorMessages = (error?: FrappeError | null): ParsedErrorMessage[] => {
         }
     })
 
-    if (eMessages.length === 0) {
+    // Filter out messages with empty content - Frappe sometimes returns messages with empty string
+    eMessages = eMessages.filter(m => m.message && m.message.trim() !== '')
+    // Check _error_message first - Frappe often puts the actual error here for PermissionError
+    if ((error as any)?._error_message) {
+        eMessages = [{
+            message: (error as any)._error_message,
+            title: error.exc_type || "Error"
+        }]
+    } else {
         // Get the message from the exception by removing the exc_type
         const indexOfFirstColon = error?.exception?.indexOf(':')
         if (indexOfFirstColon) {
@@ -75,7 +83,16 @@ export const ErrorBanner = ({ error, overrideHeading, children }: ErrorBannerPro
             }
         })
 
-        if (eMessages.length === 0) {
+        // Filter out messages with empty content - Frappe sometimes returns messages with empty string
+        eMessages = eMessages.filter(m => m.message && m.message.trim() !== '')
+        // Check _error_message first - Frappe often puts the actual error here for PermissionError
+        if ((error as any)?._error_message) {
+            eMessages = [{
+                message: (error as any)._error_message,
+                title: error.exc_type || "Error"
+            }]
+        } else {
+            if (eMessages.length === 0) {
             // Get the message from the exception by removing the exc_type
             const indexOfFirstColon = error?.exception?.indexOf(':')
             if (indexOfFirstColon) {
@@ -95,6 +112,8 @@ export const ErrorBanner = ({ error, overrideHeading, children }: ErrorBannerPro
                     indicator: "red"
                 }]
             }
+        }
+
         }
         return eMessages
     }, [error])


### PR DESCRIPTION
Not sure why we had excluded Permission Errors in ErrorBanner? @nikkothari22 

<img width="722" height="343" alt="CleanShot 2026-01-18 at 17 40 43" src="https://github.com/user-attachments/assets/03c26de4-1de3-42ba-bf6f-ced676852c71" />
