### PR TITLE
fix: Require type annotations for all API methods

### DIFF
--- a/raven/hooks.py
+++ b/raven/hooks.py
@@ -271,6 +271,7 @@ on_session_creation = "raven.api.user_availability.set_user_active"
 on_logout = "raven.api.user_availability.set_user_inactive"
 
 export_python_type_annotations = True
+require_type_annotated_api_methods = True
 
 raven_document_link_override = "raven.api.document_link.get_new_app_document_links"
 


### PR DESCRIPTION
Refer https://github.com/frappe/frappe/pull/36744