### PR TITLE
fix(mobile): fix Android push notification registration and channel setup

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -79,7 +79,7 @@
           "android": {
             "targetSdkVersion": 35,
             "buildToolsVersion": "35.0.0",
-            "compileSdkVersion": 34
+            "compileSdkVersion": 35
           }
         }
       ],

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -15,6 +15,7 @@ import { useAsyncStorage } from '@react-native-async-storage/async-storage';
 import { Toaster } from 'sonner-native';
 import { LogBox, Platform } from 'react-native';
 import { getMessaging } from '@react-native-firebase/messaging';
+import notifee, { AndroidImportance } from '@notifee/react-native';
 import { setDefaultSite } from '@lib/auth';
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
@@ -78,6 +79,15 @@ export default function RootLayout() {
         const onMount = async () => {
 
             try {
+                // Create the Android notification channel so the app appears in system notification settings
+                if (Platform.OS === 'android') {
+                    await notifee.createChannel({
+                        id: 'raven-default',
+                        name: 'Raven Notifications',
+                        importance: AndroidImportance.HIGH,
+                    })
+                }
+
                 // Get the defualt site from the async storage
                 // Also check if the app was started by a notification
                 const initialNotification = await messaging.getInitialNotification();

--- a/apps/mobile/components/features/profile/profile-settings/NotificationSetting.tsx
+++ b/apps/mobile/components/features/profile/profile-settings/NotificationSetting.tsx
@@ -28,25 +28,27 @@ const NotificationSetting = () => {
         if (enabled) {
             messaging.requestPermission().then((authorizationStatus) => {
                 if (authorizationStatus !== AuthorizationStatus.AUTHORIZED && authorizationStatus !== AuthorizationStatus.EPHEMERAL) {
-                    throw new Error('User has not granted permission to receive notifications.')
+                    toast.error('Permission denied. Please enable notifications in your device settings.')
+                    return
                 }
-            }).then(() => {
                 messaging.getToken().then((token) => {
                     if (token) {
                         call.post('raven.api.notification.subscribe', {
                             fcm_token: token,
                             environment: 'Mobile',
                             device_information: Device.deviceName
-
                         }).then(() => {
                             setEnabled(true)
-                        }).catch((error) => {
+                            toast.success('Push notifications enabled.')
+                        }).catch(() => {
                             toast.error('Failed to subscribe to push notifications.')
                         })
                     } else {
-                        toast.error('Failed to get token to subscribe.')
+                        toast.error('Failed to get device token.')
                     }
                 })
+            }).catch(() => {
+                toast.error('Failed to request notification permission.')
             })
         } else {
             messaging.getToken().then((token) => {

--- a/apps/mobile/firebase.json
+++ b/apps/mobile/firebase.json
@@ -1,0 +1,5 @@
+{
+  "react-native": {
+    "messaging_android_notification_channel_id": "raven-default"
+  }
+}

--- a/apps/mobile/hooks/useFirebasePushTokenListener.ts
+++ b/apps/mobile/hooks/useFirebasePushTokenListener.ts
@@ -16,22 +16,20 @@ const useFirebasePushTokenListener = () => {
 
     useEffect(() => {
 
-        if (callMade.current) return
+        if (!siteInfo || callMade.current) return
         callMade.current = true
 
         // When the site is switched, fetch the token and store it in the database
-        if (siteInfo) {
-            messaging.requestPermission().then(async (authorizationStatus) => {
-                if (authorizationStatus === AuthorizationStatus.AUTHORIZED) {
-                    const token = await messaging.getToken()
-                    call.post('raven.api.notification.subscribe', {
-                        fcm_token: token,
-                        environment: 'Mobile',
-                        device_information: Device.deviceName
-                    })
-                }
-            })
-        }
+        messaging.requestPermission().then(async (authorizationStatus) => {
+            if (authorizationStatus === AuthorizationStatus.AUTHORIZED) {
+                const token = await messaging.getToken()
+                call.post('raven.api.notification.subscribe', {
+                    fcm_token: token,
+                    environment: 'Mobile',
+                    device_information: Device.deviceName
+                })
+            }
+        })
 
     }, [siteInfo])
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,6 +16,7 @@
     "@expo/react-native-action-sheet": "^4.1.0",
     "@gorhom/bottom-sheet": "5.0.6",
     "@legendapp/list": "^2.0.9",
+    "@notifee/react-native": "^9.1.8",
     "@raven/lib": "*",
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-firebase/app": "^21.11.0",


### PR DESCRIPTION
## Summary

- **Fix race condition in FCM token registration**: `callMade` ref was being set to `true` before checking if `siteInfo` was available, causing the effect to bail out on every app launch after the first render (when `siteInfo` is still `null`). Token was never sent to the server.
- **Add Android notification channel**: Added `firebase.json` with `messaging_android_notification_channel_id` and create the `raven-default` channel at app startup using `@notifee/react-native`. Without this, the app does not appear in Android Settings > Notifications (required on Android 8+).
- **Fix silent error handling in notification toggle**: Errors from `requestPermission` were being swallowed silently. Added proper error toasts and a success toast so users get feedback when enabling/disabling notifications.
- **Fix `compileSdkVersion` 34 → 35**: `androidx.core:core-splashscreen:1.2.0-alpha02` requires compileSdk 35+, causing Gradle build failures.

## Test plan

- [ ] Enable push notifications from Profile > Settings on Android
- [ ] Verify success toast appears
- [ ] Close the app fully and reopen — notifications should still be active
- [ ] Check Android Settings > Notifications — Raven should appear in the list
- [ ] Send a message in a channel — push notification should be received

Work done by Claude (claude.ai)