### PR TITLE
fix(notifications)!: improve notification handling in service worker

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -21,21 +21,25 @@ try {
     }
 
     onBackgroundMessage(messaging, (payload) => {
-        const notificationTitle = payload.notification.title
+        const data = payload.data || {}
+        const notification = payload.notification || {}
+
+        const notificationTitle = data.title || notification.title
         let notificationOptions = {
-            body: payload.notification.body || "",
-        }
-        if (payload.data.image) {
-            notificationOptions["icon"] = payload.data.image
+            body: data.body || notification.body || "",
         }
 
-        if (payload.data.creation) {
-            notificationOptions["timestamp"] = payload.data.creation
+        if (data.image) {
+            notificationOptions["icon"] = data.image
         }
-        let url = `${payload.data.base_url}/raven/channel/${payload.data.channel_id}`
 
-        if (payload.data.message_url) {
-            url = payload.data.message_url
+        if (data.creation) {
+            notificationOptions["timestamp"] = data.creation
+        }
+        let url = `${data.base_url}/raven/channel/${data.channel_id}`
+
+        if (data.message_url) {
+            url = data.message_url
         }
 
         if (isChrome()) {


### PR DESCRIPTION
### Why
Per [Firebase docs](https://firebase.google.com/docs/cloud-messaging/web/receive-messages), a push with both notification and data payload makes FCM's default handler auto-display a notification and trigger onBackgroundMessage — our SW then renders a second one via showNotification(), so users see two notifications for every push on PWAs.

Paired with the [backend change](https://github.com/The-Commit-Company/raven-cloud/pull/44) (Raven Cloud now sends Web clients a data-only payload), this ensures FCM no longer auto-displays and our SW remains the sole renderer — exactly one notification per push, with all existing click routing / Chrome-vs-others behavior preserved.

### On Rollout
We need some way to communicate this to everyone using Raven to update to new version once this is merged. @nikkothari22 